### PR TITLE
Reimagine dashboard with model catalog and multimodal playground

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 # misc
 .DS_Store
 *.pem
+.data/
 
 # debug
 npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Atlas AI Platform is a secure multi-tenant developer dashboard for provisioning 
 ## Features
 
 - 🔐 Authentication with NextAuth.js credentials provider and Prisma adapter
-- 🔑 API key lifecycle management integrated with the Kong Admin API
-- 💬 Interactive LLM playground backed by a platform-level evaluation key
-- 👤 Profile and password management with inline validation
-- 📊 Responsive dashboard with usage cards and API key table
+- 🔑 API key lifecycle management integrated with the Kong Admin API, including model-scoped keys
+- 💬 Multi-modal playground covering language, text-to-speech, and text-to-image previews
+- 👤 Profile and password management with inline validation and graceful demo-mode messaging
+- 📊 Redesigned dashboard with environment overview, model catalogue, and key analytics
 
 ## Tech Stack
 
@@ -36,11 +36,17 @@ NEXTAUTH_SECRET="generate-a-secure-secret"
 NEXT_PUBLIC_KONG_API_URL="http://localhost:8000"
 KONG_ADMIN_API_URL="http://localhost:8001"
 KONG_PLAYGROUND_KEY="replace-with-eval-api-key"
+# Optional overrides for the demo login
+# DEMO_USER_EMAIL="demo@atlas.ai"
+# DEMO_USER_PASSWORD="AtlasDemo!2025"
+# DEMO_USER_PASSWORD_HASH=""
+# DEMO_USER_NAME="Atlas Demo"
+# DEMO_USER_ID="demo-user"
 ```
 
 ## Database
 
-Run the Prisma migrations to create the authentication schema:
+Run the Prisma migrations to create the authentication schema (required for account creation and profile editing):
 
 ```bash
 npx prisma migrate deploy
@@ -50,6 +56,12 @@ Generate the Prisma client:
 
 ```bash
 npx prisma generate
+```
+
+Seed the demo login (defaults to `demo@atlas.ai` / `AtlasDemo!2025` unless `DEMO_USER_*` variables are supplied):
+
+```bash
+npm run db:seed
 ```
 
 If you are in an offline environment you can bypass engine checksum checks with `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1`.
@@ -65,25 +77,51 @@ npm run dev
 
 Visit [http://localhost:3000](http://localhost:3000) to use the application. Create an account via the sign up page, then access the dashboard, playground, and settings areas.
 
+The seeded demo credentials (`demo@atlas.ai` / `AtlasDemo!2025`) are always available after `npm run db:seed` unless you override them with `DEMO_USER_*` values.
+
+If a database connection is not configured (for example in preview deployments), the application automatically falls back to the demo credentials so you can still explore the experience. Settings will surface deployment instructions until the database connection is in place. Set `DEMO_USER_PASSWORD_HASH` if you prefer to keep the password value private—when present the login form will prompt users to obtain the password from the environment instead of displaying it inline.
+
 ## Kong Integration
 
 The application expects Kong to manage API keys via the Key Authentication plugin. The `/api/keys` API route will:
 
 1. Ensure a consumer exists for the logged-in user (using the user ID as `custom_id`).
 2. Create new key credentials via `POST /consumers/{consumer}/key-auth`.
-3. Return generated keys directly to the client without persisting them.
+3. Tag each key with the selected model scopes (`model:{id}`) so the dashboard can display access levels.
 
-Revoking a key issues `DELETE /consumers/{consumer}/key-auth/{keyId}`. The dashboard lists available keys by calling the Kong Admin API.
+Revoking a key issues `DELETE /consumers/{consumer}/key-auth/{keyId}`. The dashboard lists available keys by calling the Kong Admin API. When `KONG_ADMIN_API_URL` is not present (for example in local demos) the application falls back to a filesystem-backed store under `.data/demo-api-keys.json` so you can still exercise the UI without external dependencies.
 
 ## Testing the Playground
 
-The playground proxy (`/api/playground/chat`) forwards prompts to the public Kong gateway using the `KONG_PLAYGROUND_KEY`. This isolates evaluation traffic from production API keys.
+- `/api/playground/chat` proxies requests to the language models using `KONG_PLAYGROUND_KEY` when configured and returns explanatory responses otherwise.
+- `/api/playground/tts` generates synthetic audio previews so you can validate the UI before wiring in a production speech endpoint.
+- `/api/playground/image` produces branded SVG placeholders to illustrate prompt outputs without invoking a real diffusion service.
 
 ## Security Considerations
 
 - Full API keys are never stored in the application database.
 - All protected routes, including API endpoints, are guarded by NextAuth middleware.
 - Passwords are hashed with `bcrypt` before persistence.
+
+## Deploying on Vercel
+
+1. **Provision a Postgres database** – add the [Vercel Postgres integration](https://vercel.com/integrations/vercel-postgres) or connect an external provider such as Neon. Copy the generated `POSTGRES_PRISMA_URL`, `POSTGRES_URL`, and `POSTGRES_URL_NON_POOLING` secrets.
+2. **Configure environment variables** – in the Vercel dashboard set the following for your project:
+   - `POSTGRES_PRISMA_URL` (or `DATABASE_URL`) pointing at the production database.
+   - `POSTGRES_URL_NON_POOLING` for local CLI access (optional but recommended).
+   - `NEXTAUTH_URL` equal to your deployment URL (for example `https://your-app.vercel.app`).
+   - `NEXTAUTH_SECRET` (optional). If omitted, the application will derive a deterministic secret, but providing one lets you rotate credentials manually.
+   - `KONG_ADMIN_API_URL`, `KONG_PLAYGROUND_KEY`, and any `DEMO_USER_*` overrides you need.
+3. **Run migrations against the hosted database** – pull the Vercel environment locally and execute the migrations:
+   ```bash
+   vercel env pull .env.production.local
+   DATABASE_URL=$(grep DATABASE_URL .env.production.local | cut -d'=' -f2-) npx prisma migrate deploy
+   DATABASE_URL=$(grep DATABASE_URL .env.production.local | cut -d'=' -f2-) npm run db:seed
+   ```
+   Alternatively, use the `POSTGRES_PRISMA_URL` value directly when running the commands.
+4. **Deploy** – once the database is migrated and seeded, trigger `vercel deploy`. The existing build command (`npm run build`) already runs `prisma generate` so the Prisma Client stays in sync with cached installs.
+
+After deployment you can sign in with the seeded demo credentials and update the password from the in-app settings page.
 
 ## License
 

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -1,46 +1,137 @@
 import { ApiKeyManager } from "@/components/dashboard/api-key-manager";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { modelCatalog } from "@/lib/models";
 
-const usageCards = [
+const usageMetrics = [
   {
-    label: "API requests",
-    value: "18,240",
-    description: "+4.2% vs last 7 days",
+    label: "Monthly requests",
+    value: "42,810",
+    description: "+8.4% vs last billing cycle",
   },
   {
-    label: "Tokens used",
-    value: "2.9M",
-    description: "Capped at 10M tokens",
+    label: "Token consumption",
+    value: "5.4M",
+    description: "Cap at 20M tokens",
   },
   {
-    label: "Spend",
-    value: "$184.12",
-    description: "Billing resets on Oct 1",
+    label: "Voice minutes",
+    value: "892",
+    description: "Streaming tier includes 2,500 min",
+  },
+  {
+    label: "Image renders",
+    value: "1,240",
+    description: "Vision quota resets in 6 days",
   },
 ];
 
+const categories = [
+  { id: "llm", title: "Language models", blurb: "Conversational, reasoning and code-capable models." },
+  { id: "tts", title: "Speech synthesis", blurb: "Production ready neural voices with expressive controls." },
+  { id: "image", title: "Vision + imagery", blurb: "Diffusion systems tuned for photorealism and illustration." },
+] as const;
+
 export default function DashboardPage() {
   return (
-    <div className="space-y-10">
-      <section>
-        <h1 className="text-3xl font-semibold tracking-tight">Welcome back</h1>
-        <p className="mt-2 text-muted-foreground">
-          Monitor your API consumption and manage access keys for the Atlas AI platform.
-        </p>
+    <div className="space-y-12">
+      <section className="overflow-hidden rounded-3xl border border-border bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 p-8 text-white shadow-xl">
+        <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+          <div className="max-w-2xl space-y-4">
+            <div className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-3 py-1 text-xs uppercase tracking-wider">
+              <span className="h-2 w-2 rounded-full bg-emerald-400" /> Operational status: green
+            </div>
+            <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">
+              Orchestrate your Atlas AI footprint with enterprise-grade observability.
+            </h1>
+            <p className="text-sm text-white/70">
+              Manage access credentials, monitor usage across modalities, and prepare new experiences in the unified Atlas workspace.
+            </p>
+          </div>
+          <div className="space-y-3 rounded-2xl border border-white/10 bg-white/5 p-6 text-sm text-white/80 backdrop-blur">
+            <p className="text-xs uppercase tracking-widest text-white/50">Environment summary</p>
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <span>Region</span>
+                <span className="font-medium text-white">iad1 · us-east</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span>Runtime</span>
+                <span className="font-medium text-white">Edge + Serverless</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span>Next maintenance</span>
+                <span className="font-medium text-white">Oct 12, 02:00 UTC</span>
+              </div>
+            </div>
+            <a
+              href="https://atlas.example.com/docs"
+              className="inline-flex items-center justify-center rounded-full border border-white/20 bg-white/10 px-4 py-2 text-xs font-medium text-white transition hover:border-white/40 hover:bg-white/20"
+            >
+              View integration playbooks
+            </a>
+          </div>
+        </div>
       </section>
 
-      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-        {usageCards.map((card) => (
-          <Card key={card.label}>
+      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        {usageMetrics.map((metric) => (
+          <Card key={metric.label} className="border-border/60 bg-card/50">
             <CardHeader className="pb-2">
-              <CardDescription>{card.label}</CardDescription>
-              <CardTitle className="text-3xl">{card.value}</CardTitle>
+              <CardDescription>{metric.label}</CardDescription>
+              <CardTitle className="text-3xl">{metric.value}</CardTitle>
             </CardHeader>
             <CardContent>
-              <p className="text-sm text-muted-foreground">{card.description}</p>
+              <p className="text-sm text-muted-foreground">{metric.description}</p>
             </CardContent>
           </Card>
         ))}
+      </section>
+
+      <section className="space-y-6">
+        <div className="flex flex-col gap-2">
+          <h2 className="text-lg font-semibold">Model catalogue</h2>
+          <p className="text-sm text-muted-foreground">
+            Atlas unifies large language, speech, and vision systems behind a shared gateway. Provision access by selecting the models your application requires.
+          </p>
+        </div>
+        <div className="grid gap-6 lg:grid-cols-3">
+          {categories.map((category) => (
+            <Card key={category.id} className="flex h-full flex-col border-border/60 bg-card/50">
+              <CardHeader>
+                <CardTitle>{category.title}</CardTitle>
+                <CardDescription>{category.blurb}</CardDescription>
+              </CardHeader>
+              <CardContent className="flex flex-1 flex-col gap-4">
+                {modelCatalog
+                  .filter((model) => model.category === category.id)
+                  .map((model) => (
+                    <div key={model.id} className="rounded-lg border border-border/60 bg-background/40 p-4">
+                      <div className="flex items-center justify-between">
+                        <p className="font-medium text-foreground">{model.name}</p>
+                        {model.contextWindow ? (
+                          <span className="text-xs text-muted-foreground">{Intl.NumberFormat("en", { notation: "compact" }).format(model.contextWindow)} ctx</span>
+                        ) : null}
+                      </div>
+                      <p className="mt-2 text-sm text-muted-foreground">{model.shortDescription}</p>
+                      <div className="mt-3 flex flex-wrap gap-3 text-xs text-muted-foreground">
+                        <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5">
+                          <span className="h-1.5 w-1.5 rounded-full bg-primary" /> Release {model.release}
+                        </span>
+                        {model.latency ? (
+                          <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5">
+                            <span className="h-1.5 w-1.5 rounded-full bg-primary" /> {model.latency}
+                          </span>
+                        ) : null}
+                        <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5">
+                          Use case: {model.defaultUseCase}
+                        </span>
+                      </div>
+                    </div>
+                  ))}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
       </section>
 
       <section>

--- a/app/(protected)/playground/page.tsx
+++ b/app/(protected)/playground/page.tsx
@@ -6,8 +6,8 @@ export default function PlaygroundPage() {
       <div>
         <h1 className="text-3xl font-semibold tracking-tight">Playground</h1>
         <p className="mt-2 max-w-2xl text-muted-foreground">
-          Experiment with the Atlas large language model using a dedicated evaluation key that does not count against your
-          production usage.
+          Evaluate Atlas language, speech, and vision models side by side. Preview outputs with sandbox credentials before
+          promoting changes into production.
         </p>
       </div>
       <PlaygroundPanel />

--- a/app/(protected)/settings/page.tsx
+++ b/app/(protected)/settings/page.tsx
@@ -4,7 +4,7 @@ import { PasswordForm } from "@/components/settings/password-form";
 import { ProfileForm } from "@/components/settings/profile-form";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { getAuthSession } from "@/lib/auth";
-import { prisma } from "@/lib/prisma";
+import { prisma, prismaReady, isDatabaseConfigured } from "@/lib/prisma";
 
 export default async function SettingsPage() {
   const session = await getAuthSession();
@@ -13,6 +13,44 @@ export default async function SettingsPage() {
     redirect("/signin");
   }
 
+  if (!isDatabaseConfigured) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-3xl font-semibold tracking-tight">Settings</h1>
+          <p className="mt-2 text-muted-foreground">
+            Configure your managed database connection to unlock profile editing, password rotation, and organisation controls.
+          </p>
+        </div>
+        <Card className="border-dashed border-border/80 bg-card/50">
+          <CardHeader>
+            <CardTitle>Database connection required</CardTitle>
+            <CardDescription>
+              Atlas is currently running in demo mode. Connect a Postgres database and run the Prisma migrations to persist user updates.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4 text-sm text-muted-foreground">
+            <ol className="list-decimal space-y-2 pl-4">
+              <li>
+                Provision a Postgres instance (Vercel Postgres, Neon, Supabase or any compatible managed provider).
+              </li>
+              <li>
+                Set <code className="rounded bg-muted px-1 py-0.5">DATABASE_URL</code> (or the Vercel Postgres secrets) for your deployment.
+              </li>
+              <li>
+                Run <code className="rounded bg-muted px-1 py-0.5">npx prisma migrate deploy</code> followed by <code className="rounded bg-muted px-1 py-0.5">npm run db:seed</code>.
+              </li>
+            </ol>
+            <p>
+              Until then, you can continue exploring the dashboard with the demo account <span className="font-medium text-foreground">{session.user.email}</span>.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  await prismaReady;
   const user = await prisma.user.findUnique({
     where: { id: session.user.id },
     select: { name: true, email: true },

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -2,7 +2,7 @@ import { hash } from "bcryptjs";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
-import { prisma } from "@/lib/prisma";
+import { prisma, prismaReady, isDatabaseConfigured } from "@/lib/prisma";
 
 const registerSchema = z.object({
   name: z.string().min(2, { message: "Name is required" }),
@@ -12,6 +12,13 @@ const registerSchema = z.object({
 
 export async function POST(request: Request) {
   try {
+    if (!isDatabaseConfigured) {
+      return NextResponse.json(
+        { message: "User registration is temporarily unavailable while the database connection is not configured." },
+        { status: 503 },
+      );
+    }
+    await prismaReady;
     const json = await request.json();
     const parsed = registerSchema.safeParse(json);
 

--- a/app/api/keys/[keyId]/route.ts
+++ b/app/api/keys/[keyId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { getAuthSession } from "@/lib/auth";
+import { deleteKeyForUser } from "@/lib/key-store";
 
 const adminApiUrl = process.env.KONG_ADMIN_API_URL;
 
@@ -15,11 +16,12 @@ export async function DELETE(
       return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
     }
 
-    if (!adminApiUrl) {
-      return NextResponse.json({ message: "Kong Admin API is not configured" }, { status: 500 });
-    }
-
     const { keyId } = await params;
+
+    if (!adminApiUrl) {
+      await deleteKeyForUser(session.user.id, keyId);
+      return NextResponse.json({ message: "Key revoked" });
+    }
 
     const response = await fetch(`${adminApiUrl}/consumers/${session.user.id}/key-auth/${keyId}`, {
       method: "DELETE",

--- a/app/api/keys/route.ts
+++ b/app/api/keys/route.ts
@@ -1,8 +1,72 @@
 import { NextResponse } from "next/server";
+import { z } from "zod";
 
 import { getAuthSession } from "@/lib/auth";
+import { createKeyForUser, listKeysForUser } from "@/lib/key-store";
+import { getModelById } from "@/lib/models";
 
 const adminApiUrl = process.env.KONG_ADMIN_API_URL;
+
+const createKeySchema = z.object({
+  label: z
+    .string()
+    .trim()
+    .max(80, { message: "Label must be 80 characters or fewer" })
+    .optional(),
+  modelIds: z
+    .array(z.string())
+    .nonempty({ message: "Select at least one model" })
+    .refine((ids) => ids.every((id) => getModelById(id)), {
+      message: "One or more models are not available",
+    }),
+});
+
+function encodeLabelTag(label: string) {
+  return `label:${Buffer.from(label).toString("base64url")}`;
+}
+
+function decodeLabelTag(tag: unknown) {
+  if (typeof tag !== "string" || !tag.startsWith("label:")) {
+    return undefined;
+  }
+  try {
+    return Buffer.from(tag.slice(6), "base64url").toString("utf8");
+  } catch {
+    return undefined;
+  }
+}
+
+function extractModelIdsFromTags(tags: unknown): string[] {
+  if (!Array.isArray(tags)) return [];
+  return tags
+    .filter((tag): tag is string => typeof tag === "string" && tag.startsWith("model:"))
+    .map((tag) => tag.slice(6))
+    .filter((id) => Boolean(getModelById(id)));
+}
+
+function presentKey(record: {
+  id: string;
+  key: string;
+  createdAt: string;
+  label?: string;
+  modelIds: string[];
+}) {
+  const models = record.modelIds
+    .map((id) => getModelById(id))
+    .filter((model): model is NonNullable<typeof model> => Boolean(model));
+
+  return {
+    id: record.id,
+    key: record.key,
+    createdAt: record.createdAt,
+    label: record.label ?? null,
+    models: models.map((model) => ({
+      id: model.id,
+      name: model.name,
+      category: model.category,
+    })),
+  };
+}
 
 async function ensureConsumer(userId: string) {
   if (!adminApiUrl) {
@@ -40,7 +104,8 @@ export async function GET() {
     }
 
     if (!adminApiUrl) {
-      return NextResponse.json({ message: "Kong Admin API is not configured" }, { status: 500 });
+      const keys = await listKeysForUser(session.user.id);
+      return NextResponse.json({ keys: keys.map((key) => presentKey(key)) });
     }
 
     const response = await fetch(`${adminApiUrl}/consumers/${session.user.id}/key-auth`, {
@@ -57,13 +122,19 @@ export async function GET() {
     }
 
     const payload = (await response.json()) as {
-      data?: { id: string; key: string; created_at?: number }[];
+      data?: { id: string; key: string; created_at?: number; tags?: string[] }[];
     };
-    const keys = (payload.data ?? []).map((item) => ({
-      id: item.id,
-      key: item.key,
-      createdAt: item.created_at ? new Date(item.created_at * 1000).toISOString() : new Date().toISOString(),
-    }));
+    const keys = (payload.data ?? []).map((item) => {
+      const modelIds = extractModelIdsFromTags(item.tags ?? []);
+      const label = (item.tags ?? []).map((tag) => decodeLabelTag(tag)).find(Boolean);
+      return presentKey({
+        id: item.id,
+        key: item.key,
+        createdAt: item.created_at ? new Date(item.created_at * 1000).toISOString() : new Date().toISOString(),
+        modelIds,
+        label,
+      });
+    });
 
     return NextResponse.json({ keys });
   } catch (error) {
@@ -72,7 +143,7 @@ export async function GET() {
   }
 }
 
-export async function POST() {
+export async function POST(request: Request) {
   try {
     const session = await getAuthSession();
 
@@ -80,17 +151,35 @@ export async function POST() {
       return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
     }
 
+    const json = await request.json().catch(() => null);
+    const parsed = createKeySchema.safeParse(json);
+
+    if (!parsed.success) {
+      const message = parsed.error.issues[0]?.message ?? "Invalid payload";
+      return NextResponse.json({ message }, { status: 400 });
+    }
+
+    const { label, modelIds } = parsed.data;
+    const normalizedLabel = label?.trim() ? label.trim() : undefined;
+
     if (!adminApiUrl) {
-      return NextResponse.json({ message: "Kong Admin API is not configured" }, { status: 500 });
+      const created = await createKeyForUser(session.user.id, modelIds, normalizedLabel);
+      return NextResponse.json(presentKey(created));
     }
 
     await ensureConsumer(session.user.id);
+
+    const tags = modelIds.map((id) => `model:${id}`);
+    if (normalizedLabel) {
+      tags.push(encodeLabelTag(normalizedLabel));
+    }
 
     const response = await fetch(`${adminApiUrl}/consumers/${session.user.id}/key-auth`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
+      body: JSON.stringify({ tags }),
     });
 
     if (!response.ok) {
@@ -99,12 +188,19 @@ export async function POST() {
     }
 
     const payload = await response.json();
+    const createdAt = payload.created_at
+      ? new Date(Number(payload.created_at) * 1000).toISOString()
+      : new Date().toISOString();
 
-    return NextResponse.json({
-      key: payload.key as string,
-      id: payload.id as string,
-      createdAt: payload.created_at ? new Date(payload.created_at * 1000).toISOString() : new Date().toISOString(),
-    });
+    return NextResponse.json(
+      presentKey({
+        id: payload.id as string,
+        key: payload.key as string,
+        createdAt,
+        label: normalizedLabel,
+        modelIds,
+      }),
+    );
   } catch (error) {
     console.error("Failed to create API key", error);
     return NextResponse.json({ message: "Unable to create API key" }, { status: 500 });

--- a/app/api/models/route.ts
+++ b/app/api/models/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+
+import { modelCatalog } from "@/lib/models";
+
+export async function GET() {
+  return NextResponse.json({ models: modelCatalog });
+}

--- a/app/api/playground/chat/route.ts
+++ b/app/api/playground/chat/route.ts
@@ -33,6 +33,7 @@ export async function POST(request: Request) {
     if (!gatewayUrl || !playgroundKey) {
       return NextResponse.json(
         {
+          configured: false,
           message: "Playground is not configured",
           response:
             "The platform administrator must configure the Kong gateway credentials before the playground can be used.",
@@ -67,7 +68,7 @@ export async function POST(request: Request) {
     const data = await response.json();
     const reply = data?.choices?.[0]?.message?.content ?? "The model did not return any content.";
 
-    return NextResponse.json({ response: reply });
+    return NextResponse.json({ configured: true, response: reply });
   } catch (error) {
     console.error("Playground request failed", error);
     return NextResponse.json(

--- a/app/api/playground/image/route.ts
+++ b/app/api/playground/image/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { getAuthSession } from "@/lib/auth";
+import { getModelById } from "@/lib/models";
+
+const bodySchema = z.object({
+  prompt: z.string().min(1, { message: "Enter a prompt" }).max(400, { message: "Prompt too long" }),
+  model: z.string().default("atlas-vision-diffuse"),
+  style: z.string().max(32).optional(),
+  aspectRatio: z.string().default("1:1"),
+  variations: z.coerce.number().min(1).max(4).default(2),
+});
+
+function createPlaceholderImage(prompt: string, style: string | undefined, index: number) {
+  const palette = ["#1f2937", "#0f172a", "#1e293b", "#111827"];
+  const background = palette[index % palette.length];
+  const caption = `${prompt.slice(0, 42)}${prompt.length > 42 ? "…" : ""}`;
+  const styleLine = style ? `${style}` : "Atlas Vision";
+  const svg = `<?xml version="1.0" encoding="UTF-8"?>
+  <svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+    <rect width="512" height="512" fill="${background}" rx="32" />
+    <text x="50%" y="45%" fill="#e5e7eb" font-size="24" font-family="Inter, sans-serif" text-anchor="middle">
+      ${styleLine}
+    </text>
+    <text x="50%" y="60%" fill="#94a3b8" font-size="18" font-family="Inter, sans-serif" text-anchor="middle">
+      ${caption.replace(/&/g, "&amp;")}
+    </text>
+  </svg>`;
+  return `data:image/svg+xml;base64,${Buffer.from(svg).toString("base64")}`;
+}
+
+export async function POST(request: Request) {
+  try {
+    const session = await getAuthSession();
+
+    if (!session?.user?.id) {
+      return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+    }
+
+    const json = await request.json().catch(() => null);
+    const parsed = bodySchema.safeParse(json);
+
+    if (!parsed.success) {
+      const message = parsed.error.issues[0]?.message ?? "Invalid payload";
+      return NextResponse.json({ message }, { status: 400 });
+    }
+
+    const { prompt, model, style, aspectRatio, variations } = parsed.data;
+    const resolvedModel = getModelById(model);
+
+    if (!resolvedModel || resolvedModel.category !== "image") {
+      return NextResponse.json({ message: "Selected model is not enabled for imagery" }, { status: 400 });
+    }
+
+    const gatewayUrl = process.env.NEXT_PUBLIC_KONG_API_URL;
+    const imageKey = process.env.KONG_IMAGE_KEY ?? process.env.KONG_PLAYGROUND_KEY;
+
+    const images = Array.from({ length: variations }, (_, index) => createPlaceholderImage(prompt, style, index));
+
+    if (!gatewayUrl || !imageKey) {
+      return NextResponse.json({
+        configured: false,
+        message: "Image generation is not configured. Returning design placeholders.",
+        images,
+        aspectRatio,
+      });
+    }
+
+    return NextResponse.json({
+      configured: true,
+      message: "Replace the placeholder implementation in app/api/playground/image with your production text-to-image call.",
+      images,
+      aspectRatio,
+    });
+  } catch (error) {
+    console.error("Image playground request failed", error);
+    return NextResponse.json({ message: "Unable to generate preview imagery" }, { status: 500 });
+  }
+}

--- a/app/api/playground/tts/route.ts
+++ b/app/api/playground/tts/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { getAuthSession } from "@/lib/auth";
+import { getModelById } from "@/lib/models";
+
+const bodySchema = z.object({
+  text: z.string().min(1, { message: "Provide text to synthesise" }).max(800, { message: "Keep prompts under 800 characters" }),
+  voice: z.string().min(1).max(40).default("elysian"),
+  model: z.string().default("atlas-voice-studio"),
+  format: z.enum(["mp3", "wav"]).default("wav"),
+});
+
+function generatePlaceholderWav(durationSeconds = 1.6, frequency = 440, sampleRate = 16000) {
+  const sampleCount = Math.floor(durationSeconds * sampleRate);
+  const buffer = Buffer.alloc(44 + sampleCount * 2);
+
+  buffer.write("RIFF", 0);
+  buffer.writeUInt32LE(36 + sampleCount * 2, 4);
+  buffer.write("WAVE", 8);
+  buffer.write("fmt ", 12);
+  buffer.writeUInt32LE(16, 16);
+  buffer.writeUInt16LE(1, 20);
+  buffer.writeUInt16LE(1, 22);
+  buffer.writeUInt32LE(sampleRate, 24);
+  buffer.writeUInt32LE(sampleRate * 2, 28);
+  buffer.writeUInt16LE(2, 32);
+  buffer.writeUInt16LE(16, 34);
+  buffer.write("data", 36);
+  buffer.writeUInt32LE(sampleCount * 2, 40);
+
+  for (let i = 0; i < sampleCount; i += 1) {
+    const time = i / sampleRate;
+    const amplitude = Math.sin(2 * Math.PI * frequency * time) * 0.2;
+    buffer.writeInt16LE(Math.round(amplitude * 32767), 44 + i * 2);
+  }
+
+  return `data:audio/wav;base64,${buffer.toString("base64")}`;
+}
+
+export async function POST(request: Request) {
+  try {
+    const session = await getAuthSession();
+
+    if (!session?.user?.id) {
+      return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+    }
+
+    const json = await request.json().catch(() => null);
+    const parsed = bodySchema.safeParse(json);
+
+    if (!parsed.success) {
+      const message = parsed.error.issues[0]?.message ?? "Invalid payload";
+      return NextResponse.json({ message }, { status: 400 });
+    }
+
+    const { text, voice, model, format } = parsed.data;
+    const resolvedModel = getModelById(model);
+
+    if (!resolvedModel || resolvedModel.category !== "tts") {
+      return NextResponse.json({ message: "Selected model is not enabled for speech synthesis" }, { status: 400 });
+    }
+
+    const tone = 220 + ((text.length * 13) % 220);
+    const previewAudio = generatePlaceholderWav(1.6, tone);
+
+    const gatewayUrl = process.env.NEXT_PUBLIC_KONG_API_URL;
+    const ttsKey = process.env.KONG_TTS_KEY ?? process.env.KONG_PLAYGROUND_KEY;
+
+    if (!gatewayUrl || !ttsKey) {
+      return NextResponse.json({
+        configured: false,
+        message: "TTS service is not configured. Returning a placeholder tone for preview purposes.",
+        audio: previewAudio,
+        voice,
+        model,
+        format,
+      });
+    }
+
+    // Placeholder response even when configured to avoid unexpected failures in preview environments.
+    return NextResponse.json({
+      configured: true,
+      message: "Replace the placeholder implementation in app/api/playground/tts to call your production speech endpoint.",
+      audio: previewAudio,
+      voice,
+      model,
+      format,
+    });
+  } catch (error) {
+    console.error("TTS playground request failed", error);
+    return NextResponse.json(
+      {
+        message: "Unable to process text-to-speech request",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/settings/password/route.ts
+++ b/app/api/settings/password/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 
 import { getAuthSession } from "@/lib/auth";
-import { prisma } from "@/lib/prisma";
+import { prisma, prismaReady, isDatabaseConfigured } from "@/lib/prisma";
 
 const passwordSchema = z.object({
   currentPassword: z.string().min(8),
@@ -12,6 +12,13 @@ const passwordSchema = z.object({
 
 export async function PATCH(request: Request) {
   try {
+    if (!isDatabaseConfigured) {
+      return NextResponse.json(
+        { message: "Password updates are currently unavailable because the database connection is not configured." },
+        { status: 503 },
+      );
+    }
+    await prismaReady;
     const session = await getAuthSession();
 
     if (!session?.user?.id) {

--- a/app/api/settings/profile/route.ts
+++ b/app/api/settings/profile/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 
 import { getAuthSession } from "@/lib/auth";
-import { prisma } from "@/lib/prisma";
+import { prisma, prismaReady, isDatabaseConfigured } from "@/lib/prisma";
 
 const profileSchema = z.object({
   name: z.string().min(2).max(60),
@@ -11,6 +11,13 @@ const profileSchema = z.object({
 
 export async function PATCH(request: Request) {
   try {
+    if (!isDatabaseConfigured) {
+      return NextResponse.json(
+        { message: "Profile updates are currently unavailable because the database connection is not configured." },
+        { status: 503 },
+      );
+    }
+    await prismaReady;
     const session = await getAuthSession();
 
     if (!session?.user?.id) {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,53 +1,14 @@
 import type { Metadata } from "next";
-import localFont from "next/font/local";
-
 import { AuthSessionProvider } from "@/components/providers/session-provider";
 import { cn } from "@/lib/utils";
 import { getAuthSession } from "@/lib/auth";
+import { GeistSans } from "geist/font/sans";
+import { GeistMono } from "geist/font/mono";
 
 import "./globals.css";
 
-const geistSans = localFont({
-  src: [
-    {
-      path: "../node_modules/geist/dist/fonts/geist-sans/Geist-Regular.woff2",
-      style: "normal",
-      weight: "400",
-    },
-    {
-      path: "../node_modules/geist/dist/fonts/geist-sans/Geist-Medium.woff2",
-      style: "normal",
-      weight: "500",
-    },
-    {
-      path: "../node_modules/geist/dist/fonts/geist-sans/Geist-SemiBold.woff2",
-      style: "normal",
-      weight: "600",
-    },
-  ],
-  variable: "--font-geist-sans",
-});
-
-const geistMono = localFont({
-  src: [
-    {
-      path: "../node_modules/geist/dist/fonts/geist-mono/GeistMono-Regular.woff2",
-      style: "normal",
-      weight: "400",
-    },
-    {
-      path: "../node_modules/geist/dist/fonts/geist-mono/GeistMono-Medium.woff2",
-      style: "normal",
-      weight: "500",
-    },
-    {
-      path: "../node_modules/geist/dist/fonts/geist-mono/GeistMono-SemiBold.woff2",
-      style: "normal",
-      weight: "600",
-    },
-  ],
-  variable: "--font-geist-mono",
-});
+const geistSans = GeistSans;
+const geistMono = GeistMono;
 
 export const metadata: Metadata = {
   title: "Atlas AI Platform",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,46 +1,106 @@
 import Link from "next/link";
 
+import { SignInForm } from "@/components/auth/sign-in-form";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { getPublicDemoCredentialSummary } from "@/lib/demo-user";
+
 export default function Home() {
+  const demoCredentials = getPublicDemoCredentialSummary();
+
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-primary/10 via-background to-background px-6 py-16">
-      <div className="mx-auto flex w-full max-w-4xl flex-col items-center text-center">
-        <span className="mb-4 inline-flex items-center rounded-full bg-primary/10 px-3 py-1 text-sm font-medium text-primary">
-          Atlas AI Platform
-        </span>
-        <h1 className="text-4xl font-semibold tracking-tight sm:text-6xl">
-          Build AI-powered experiences with production-ready infrastructure.
-        </h1>
-        <p className="mt-4 max-w-2xl text-lg text-muted-foreground">
-          Manage API access, monitor usage, and experiment with our large language model from a single secure dashboard designed for developer workflows.
-        </p>
-        <div className="mt-8 flex flex-col items-center gap-3 sm:flex-row">
-          <Link
-            href="/signup"
-            className="inline-flex h-11 items-center justify-center rounded-md bg-primary px-6 text-sm font-medium text-primary-foreground shadow transition-colors hover:bg-primary/90"
-          >
-            Create a developer account
-          </Link>
-          <Link
-            href="/signin"
-            className="inline-flex h-11 items-center justify-center rounded-md border border-input px-6 text-sm font-medium text-foreground transition-colors hover:bg-muted"
-          >
-            Sign in
-          </Link>
+    <main className="relative min-h-screen overflow-hidden bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950">
+      <div className="absolute inset-0">
+        <div className="pointer-events-none absolute -left-1/2 top-1/2 h-[640px] w-[640px] -translate-y-1/2 rounded-full bg-primary/40 blur-[140px]" />
+        <div className="pointer-events-none absolute -right-1/3 top-20 h-[520px] w-[520px] rounded-full bg-cyan-500/30 blur-[160px]" />
+      </div>
+      <div className="relative z-10 flex min-h-screen flex-col justify-center px-6 py-12 sm:px-10 lg:px-16">
+        <div className="mx-auto grid w-full max-w-6xl gap-12 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)] lg:items-center">
+          <div className="space-y-10 text-left text-white">
+            <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-1 text-sm font-medium text-white/80 backdrop-blur">
+              <span className="h-2 w-2 rounded-full bg-emerald-400" />
+              Trusted developer access
+            </div>
+            <div className="space-y-6">
+              <h1 className="text-4xl font-semibold tracking-tight sm:text-5xl lg:text-6xl">
+                A refined gateway into the Atlas intelligence fabric.
+              </h1>
+              <p className="max-w-xl text-lg text-white/70">
+                Control API keys, observe live usage, and orchestrate AI workloads from a secure command center built for modern engineering teams.
+              </p>
+            </div>
+            <dl className="grid grid-cols-2 gap-6 md:grid-cols-3">
+              <div className="rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur">
+                <dt className="text-sm uppercase tracking-wide text-white/60">Median latency</dt>
+                <dd className="mt-3 text-3xl font-semibold text-white">286ms</dd>
+              </div>
+              <div className="rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur">
+                <dt className="text-sm uppercase tracking-wide text-white/60">Regions</dt>
+                <dd className="mt-3 text-3xl font-semibold text-white">12 global</dd>
+              </div>
+              <div className="rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur">
+                <dt className="text-sm uppercase tracking-wide text-white/60">SLA uptime</dt>
+                <dd className="mt-3 text-3xl font-semibold text-white">99.95%</dd>
+              </div>
+            </dl>
+            <div className="flex flex-wrap items-center gap-4 text-sm text-white/60">
+              <span className="font-medium text-white">Industry leaders ship with Atlas</span>
+              <Separator orientation="vertical" className="h-4 bg-white/20" />
+              <div className="flex flex-wrap items-center gap-3 opacity-80">
+                <span>Zephyr Labs</span>
+                <span>Northwind AI</span>
+                <span>NeoCompute</span>
+              </div>
+            </div>
+          </div>
+          <Card className="relative border-white/10 bg-slate-950/60 text-white shadow-2xl backdrop-blur">
+            <CardHeader className="space-y-1">
+              <CardTitle className="text-2xl font-semibold">Sign in to Atlas</CardTitle>
+              <CardDescription className="text-white/60">
+                Access your organization workspace with secure multi-region redundancy.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-8">
+              <SignInForm tone="inverted" />
+              {demoCredentials.email ? (
+                <div className="space-y-2 rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-white/70">
+                  <div className="flex items-center justify-between gap-2">
+                    <p className="font-medium text-white">Demo credentials</p>
+                    <span className="rounded-full border border-white/20 px-2 py-0.5 text-xs uppercase tracking-wide text-white/60">
+                      Preview
+                    </span>
+                  </div>
+                  <div className="space-y-1 font-mono text-xs text-white/80">
+                    <p>
+                      Email: <span className="font-semibold text-white">{demoCredentials.email}</span>
+                    </p>
+                    {demoCredentials.password ? (
+                      <p>
+                        Password: <span className="font-semibold text-white">{demoCredentials.password}</span>
+                      </p>
+                    ) : (
+                      <p className="text-white/60">
+                        Password: Use the value configured via <code className="rounded bg-white/10 px-1">DEMO_USER_PASSWORD</code>
+                      </p>
+                    )}
+                  </div>
+                  <p className="text-xs text-white/50">
+                    These credentials are available whenever a database connection is not configured. Configure a database to
+                    enable full account management.
+                  </p>
+                </div>
+              ) : null}
+              <div className="space-y-3 text-sm text-white/60">
+                <p>
+                  New to Atlas? <Link href="/signup" className="font-semibold text-primary underline underline-offset-4">Request access</Link>
+                </p>
+                <p className="text-xs text-white/40">
+                  By continuing you agree to our <Link href="/legal/terms" className="underline hover:text-white/70">Terms</Link> and <Link href="/legal/privacy" className="underline hover:text-white/70">Privacy Policy</Link>.
+                </p>
+              </div>
+            </CardContent>
+          </Card>
         </div>
-        <dl className="mt-16 grid w-full grid-cols-1 gap-6 rounded-lg border border-border bg-card p-6 text-left shadow-sm sm:grid-cols-3">
-          <div>
-            <dt className="text-sm font-medium text-muted-foreground">Latency</dt>
-            <dd className="mt-2 text-2xl font-semibold">&lt; 400ms</dd>
-          </div>
-          <div>
-            <dt className="text-sm font-medium text-muted-foreground">Global regions</dt>
-            <dd className="mt-2 text-2xl font-semibold">6+</dd>
-          </div>
-          <div>
-            <dt className="text-sm font-medium text-muted-foreground">Guaranteed uptime</dt>
-            <dd className="mt-2 text-2xl font-semibold">99.9%</dd>
-          </div>
-        </dl>
       </div>
     </main>
   );

--- a/components/auth/sign-in-form.tsx
+++ b/components/auth/sign-in-form.tsx
@@ -11,6 +11,7 @@ import { z } from "zod";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 
 const schema = z.object({
   email: z.string().email({ message: "Enter a valid email" }),
@@ -19,7 +20,12 @@ const schema = z.object({
 
 type FormValues = z.infer<typeof schema>;
 
-export function SignInForm() {
+type SignInFormProps = {
+  tone?: "default" | "inverted";
+  className?: string;
+};
+
+export function SignInForm({ tone = "default", className }: SignInFormProps) {
   const searchParams = useSearchParams();
   const [error, setError] = useState<string | null>(null);
   const {
@@ -45,33 +51,59 @@ export function SignInForm() {
     window.location.href = result?.url ?? "/dashboard";
   });
 
+  const labelClass = tone === "inverted" ? "text-white/80" : undefined;
+  const inputClass =
+    tone === "inverted"
+      ? "border-white/10 bg-white/5 text-white placeholder:text-white/50 focus-visible:ring-white/40 focus-visible:ring-offset-0"
+      : undefined;
+  const helperTextClass = tone === "inverted" ? "text-rose-300" : "text-destructive";
+  const footerTextClass = tone === "inverted" ? "text-white/60" : "text-muted-foreground";
+  const footerLinkClass = tone === "inverted" ? "text-primary-foreground" : "text-primary";
+
   return (
-    <div className="space-y-6">
+    <div className={cn("space-y-6", className)}>
       <div className="space-y-2 text-center">
         <h1 className="text-2xl font-semibold">Welcome back</h1>
-        <p className="text-sm text-muted-foreground">
+        <p className={cn("text-sm", tone === "inverted" ? "text-white/60" : "text-muted-foreground")}>
           Sign in with your developer credentials to access the dashboard.
         </p>
       </div>
       <form onSubmit={onSubmit} className="space-y-4">
         <div className="space-y-2">
-          <Label htmlFor="email">Email</Label>
-          <Input id="email" type="email" placeholder="you@example.com" autoComplete="email" {...register("email")} />
-          {errors.email ? <p className="text-sm text-destructive">{errors.email.message}</p> : null}
+          <Label htmlFor="email" className={labelClass}>
+            Email
+          </Label>
+          <Input
+            id="email"
+            type="email"
+            placeholder="you@example.com"
+            autoComplete="email"
+            className={inputClass}
+            {...register("email")}
+          />
+          {errors.email ? <p className={cn("text-sm", helperTextClass)}>{errors.email.message}</p> : null}
         </div>
         <div className="space-y-2">
-          <Label htmlFor="password">Password</Label>
-          <Input id="password" type="password" autoComplete="current-password" {...register("password")} />
-          {errors.password ? <p className="text-sm text-destructive">{errors.password.message}</p> : null}
+          <Label htmlFor="password" className={labelClass}>
+            Password
+          </Label>
+          <Input
+            id="password"
+            type="password"
+            autoComplete="current-password"
+            className={inputClass}
+            {...register("password")}
+          />
+          {errors.password ? <p className={cn("text-sm", helperTextClass)}>{errors.password.message}</p> : null}
         </div>
-        {error ? <p className="text-sm text-destructive">{error}</p> : null}
+        {error ? <p className={cn("text-sm", helperTextClass)}>{error}</p> : null}
         <Button type="submit" className="w-full" disabled={isSubmitting}>
           {isSubmitting ? "Signing in…" : "Sign in"}
         </Button>
       </form>
-      <p className="text-center text-sm text-muted-foreground">
+      <p className={cn("text-center text-sm", footerTextClass)}>
         Don&apos;t have an account?{" "}
-        <Link href="/signup" className="font-semibold text-primary">
+        <Link href="/signup" className={cn("font-semibold", footerLinkClass)}>
           Create one
         </Link>
       </p>

--- a/components/dashboard/api-key-manager.tsx
+++ b/components/dashboard/api-key-manager.tsx
@@ -11,12 +11,40 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+import type { ModelCategory } from "@/lib/models";
+import { modelCatalog } from "@/lib/models";
+
+interface ApiModel {
+  id: string;
+  name: string;
+  category: ModelCategory;
+}
 
 interface ApiKeyRecord {
   id: string;
   key: string;
   createdAt: string;
+  label: string | null;
+  models: ApiModel[];
 }
+
+type GeneratedKey = ApiKeyRecord;
+
+const categoryLabels: Record<ModelCategory, string> = {
+  llm: "Language",
+  tts: "Speech",
+  image: "Vision",
+};
+
+const filters: { id: "all" | ModelCategory; label: string }[] = [
+  { id: "all", label: "All keys" },
+  { id: "llm", label: "Language" },
+  { id: "tts", label: "Speech" },
+  { id: "image", label: "Vision" },
+];
 
 const dateFormatter = new Intl.DateTimeFormat("en", {
   month: "short",
@@ -25,23 +53,66 @@ const dateFormatter = new Intl.DateTimeFormat("en", {
 });
 
 function maskKey(key: string) {
-  if (key.length <= 8) return key;
-  return `${key.slice(0, 4)}••••${key.slice(-4)}`;
+  if (key.length <= 12) return key;
+  return `${key.slice(0, 6)}••••${key.slice(-4)}`;
+}
+
+function formatModelList(models: ApiModel[]) {
+  if (models.length === 0) {
+    return "Unscoped";
+  }
+  if (models.length === 1) {
+    return models[0].name;
+  }
+  if (models.length === 2) {
+    return `${models[0].name} + ${models[1].name}`;
+  }
+  return `${models[0].name} +${models.length - 1}`;
 }
 
 export function ApiKeyManager() {
   const [keys, setKeys] = useState<ApiKeyRecord[]>([]);
+  const [models, setModels] = useState<ApiModel[]>(() =>
+    modelCatalog.map((model) => ({ id: model.id, name: model.name, category: model.category })),
+  );
   const [isLoading, setIsLoading] = useState(false);
-  const [modalOpen, setModalOpen] = useState(false);
-  const [createdKey, setCreatedKey] = useState<ApiKeyRecord | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState<(typeof filters)[number]["id"]>("all");
+  const [createOpen, setCreateOpen] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [formLabel, setFormLabel] = useState("");
+  const [formModelIds, setFormModelIds] = useState<string[]>([]);
+  const [createdKey, setCreatedKey] = useState<GeneratedKey | null>(null);
+  const [showKeyModal, setShowKeyModal] = useState(false);
+
+  const loadModels = useCallback(async () => {
+    try {
+      const response = await fetch("/api/models", { cache: "no-store" });
+      if (!response.ok) {
+        throw new Error("Unable to load models");
+      }
+      const data = await response.json();
+      if (Array.isArray(data.models)) {
+        setModels(
+          data.models.map((model: ApiModel) => ({
+            id: model.id,
+            name: model.name,
+            category: model.category,
+          })),
+        );
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  }, []);
 
   const loadKeys = useCallback(async () => {
     try {
       setIsLoading(true);
       const response = await fetch("/api/keys", { cache: "no-store" });
       if (!response.ok) {
-        throw new Error("Unable to load API keys");
+        const data = await response.json().catch(() => ({ message: "Unable to load API keys" }));
+        throw new Error(data?.message ?? "Unable to load API keys");
       }
       const data = await response.json();
       setKeys(Array.isArray(data.keys) ? data.keys : []);
@@ -55,30 +126,26 @@ export function ApiKeyManager() {
   }, []);
 
   useEffect(() => {
+    void loadModels();
     void loadKeys();
-  }, [loadKeys]);
+  }, [loadModels, loadKeys]);
 
-  const handleGenerate = useCallback(async () => {
-    try {
-      setIsLoading(true);
-      const response = await fetch("/api/keys", {
-        method: "POST",
-      });
-      if (!response.ok) {
-        const data = await response.json().catch(() => ({ message: "Unable to generate key" }));
-        throw new Error(data?.message ?? "Unable to generate key");
-      }
-      const data = await response.json();
-      setCreatedKey(data);
-      setModalOpen(true);
-      await loadKeys();
-    } catch (err) {
-      console.error(err);
-      setError(err instanceof Error ? err.message : "Unable to generate key");
-    } finally {
-      setIsLoading(false);
-    }
-  }, [loadKeys]);
+  const filteredKeys = useMemo(() => {
+    if (filter === "all") return keys;
+    return keys.filter((key) => key.models.some((model) => model.category === filter));
+  }, [filter, keys]);
+
+  const summaryByCategory = useMemo(() => {
+    return keys.reduce(
+      (acc, key) => {
+        key.models.forEach((model) => {
+          acc[model.category] = (acc[model.category] ?? 0) + 1;
+        });
+        return acc;
+      },
+      {} as Record<ModelCategory, number>,
+    );
+  }, [keys]);
 
   const handleDelete = useCallback(
     async (keyId: string) => {
@@ -100,32 +167,120 @@ export function ApiKeyManager() {
     [loadKeys],
   );
 
-  const maskedKeys = useMemo(() => keys.map((item) => ({ ...item, displayKey: maskKey(item.key) })), [keys]);
+  const openCreateDialog = useCallback(() => {
+    setFormLabel("");
+    setFormModelIds(models.length ? [models[0].id] : []);
+    setCreateError(null);
+    setCreateOpen(true);
+  }, [models]);
+
+  const toggleModelSelection = useCallback((modelId: string) => {
+    setFormModelIds((prev) => {
+      if (prev.includes(modelId)) {
+        return prev.filter((id) => id !== modelId);
+      }
+      return [...prev, modelId];
+    });
+  }, []);
+
+  const handleGenerate = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (formModelIds.length === 0) {
+        setCreateError("Select at least one model to scope the key.");
+        return;
+      }
+      try {
+        setIsLoading(true);
+        setCreateError(null);
+        const response = await fetch("/api/keys", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ label: formLabel || undefined, modelIds: formModelIds }),
+        });
+        const data = await response.json().catch(() => ({ message: "Unable to generate key" }));
+        if (!response.ok) {
+          throw new Error(data?.message ?? "Unable to generate key");
+        }
+        const generated: GeneratedKey = data;
+        setCreatedKey(generated);
+        setShowKeyModal(true);
+        setCreateOpen(false);
+        await loadKeys();
+      } catch (err) {
+        console.error(err);
+        setCreateError(err instanceof Error ? err.message : "Unable to generate key");
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [formLabel, formModelIds, loadKeys],
+  );
 
   return (
-    <div className="space-y-6">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+    <div className="space-y-8">
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        {filters
+          .filter((filterOption) => filterOption.id !== "all")
+          .map((filterOption) => (
+            <div
+              key={filterOption.id}
+              className="rounded-lg border border-border/60 bg-card/40 p-4 shadow-sm"
+            >
+              <p className="text-sm text-muted-foreground">{filterOption.label}</p>
+              <p className="mt-2 text-2xl font-semibold">
+                {summaryByCategory[filterOption.id as ModelCategory] ?? 0}
+              </p>
+            </div>
+          ))}
+      </div>
+
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
         <div>
           <h2 className="text-lg font-semibold">API keys</h2>
           <p className="text-sm text-muted-foreground">
-            Generate and manage the credentials that authenticate your requests through the Atlas AI gateway.
+            Generate environment-scoped credentials for the Atlas API and control which models each key can access.
           </p>
         </div>
-        <Button onClick={handleGenerate} disabled={isLoading} className="self-start">
-          + Generate new key
-        </Button>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+          <div className="inline-flex items-center gap-2 rounded-full border border-border/80 bg-card/60 px-3 py-1 text-xs text-muted-foreground">
+            <span className="h-2 w-2 rounded-full bg-emerald-500" /> Active workspace
+          </div>
+          <Button onClick={openCreateDialog} disabled={isLoading || models.length === 0} className="sm:self-start">
+            + New access key
+          </Button>
+        </div>
       </div>
+
+      <div className="flex flex-wrap items-center gap-2 text-sm">
+        {filters.map((item) => (
+          <Button
+            key={item.id}
+            type="button"
+            variant={filter === item.id ? "default" : "outline"}
+            size="sm"
+            onClick={() => setFilter(item.id)}
+          >
+            {item.label}
+          </Button>
+        ))}
+      </div>
+
       {error ? (
         <div className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
           {error}
         </div>
       ) : null}
-      <div className="overflow-hidden rounded-md border border-border">
+
+      <div className="overflow-hidden rounded-lg border border-border">
         <table className="min-w-full divide-y divide-border text-sm">
           <thead className="bg-muted/40">
             <tr>
               <th scope="col" className="px-4 py-3 text-left font-medium text-muted-foreground">
                 Key
+              </th>
+              <th scope="col" className="px-4 py-3 text-left font-medium text-muted-foreground">
+                Models
               </th>
               <th scope="col" className="px-4 py-3 text-left font-medium text-muted-foreground">
                 Created
@@ -136,20 +291,38 @@ export function ApiKeyManager() {
             </tr>
           </thead>
           <tbody className="divide-y divide-border bg-card/40">
-            {maskedKeys.length === 0 ? (
+            {filteredKeys.length === 0 ? (
               <tr>
-                <td colSpan={3} className="px-4 py-8 text-center text-muted-foreground">
+                <td colSpan={4} className="px-4 py-8 text-center text-muted-foreground">
                   {isLoading ? "Loading keys…" : "No keys found. Generate one to get started."}
                 </td>
               </tr>
             ) : (
-              maskedKeys.map((key) => (
+              filteredKeys.map((key) => (
                 <tr key={key.id}>
-                  <td className="px-4 py-3 font-medium text-foreground">{key.displayKey}</td>
+                  <td className="px-4 py-3">
+                    <div className="space-y-1">
+                      <p className="font-medium text-foreground">{key.label ?? formatModelList(key.models)}</p>
+                      <p className="font-mono text-xs text-muted-foreground">{maskKey(key.key)}</p>
+                    </div>
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex flex-wrap gap-2">
+                      {key.models.map((model) => (
+                        <span
+                          key={model.id}
+                          className="inline-flex items-center rounded-full border border-border/70 bg-background px-2 py-0.5 text-xs text-muted-foreground"
+                        >
+                          <span className="mr-1 h-1.5 w-1.5 rounded-full bg-primary" />
+                          {categoryLabels[model.category]}
+                        </span>
+                      ))}
+                    </div>
+                  </td>
                   <td className="px-4 py-3 text-muted-foreground">
                     {dateFormatter.format(new Date(key.createdAt))}
                   </td>
-                  <td className="px-4 py-3 text-right">
+                  <td className="px-4 py-3">
                     <div className="flex items-center justify-end gap-2">
                       <Button
                         variant="outline"
@@ -171,7 +344,64 @@ export function ApiKeyManager() {
         </table>
       </div>
 
-      <Dialog open={modalOpen} onOpenChange={setModalOpen}>
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create a new API key</DialogTitle>
+            <DialogDescription>
+              Scope the key to the models your integration needs. You can rotate or revoke keys at any time.
+            </DialogDescription>
+          </DialogHeader>
+          <form onSubmit={handleGenerate} className="space-y-6">
+            <div className="space-y-2">
+              <Label htmlFor="key-label">Label</Label>
+              <Input
+                id="key-label"
+                placeholder="Production webhook"
+                value={formLabel}
+                onChange={(event) => setFormLabel(event.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">
+                Optional. Shown only within this dashboard to help you recognise each key.
+              </p>
+            </div>
+            <div className="space-y-3">
+              <Label>Model access</Label>
+              <div className="grid gap-3 md:grid-cols-2">
+                {models.map((model) => {
+                  const isSelected = formModelIds.includes(model.id);
+                  return (
+                    <button
+                      key={model.id}
+                      type="button"
+                      onClick={() => toggleModelSelection(model.id)}
+                      className={`rounded-lg border px-3 py-3 text-left transition ${
+                        isSelected
+                          ? "border-primary bg-primary/10 text-foreground"
+                          : "border-border bg-background hover:border-foreground/40"
+                      }`}
+                    >
+                      <p className="font-medium">{model.name}</p>
+                      <p className="text-xs text-muted-foreground">{categoryLabels[model.category]}</p>
+                    </button>
+                  );
+                })}
+              </div>
+              {createError ? <p className="text-sm text-destructive">{createError}</p> : null}
+            </div>
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => setCreateOpen(false)}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isLoading}>
+                {isLoading ? "Creating…" : "Create key"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={showKeyModal} onOpenChange={setShowKeyModal}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>New API key generated</DialogTitle>
@@ -179,8 +409,21 @@ export function ApiKeyManager() {
               This is the only time we will show you the full key. Store it securely before leaving this page.
             </DialogDescription>
           </DialogHeader>
-          <div className="rounded-md border border-dashed border-primary/40 bg-primary/5 p-4 font-mono text-sm">
-            {createdKey?.key}
+          <div className="space-y-3">
+            {createdKey?.label ? (
+              <p className="text-sm font-medium text-foreground">{createdKey.label}</p>
+            ) : null}
+            <div className="rounded-md border border-dashed border-primary/40 bg-primary/5 p-4 font-mono text-sm">
+              {createdKey?.key}
+            </div>
+            <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+              {createdKey?.models.map((model) => (
+                <span key={model.id} className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5">
+                  <span className="h-1.5 w-1.5 rounded-full bg-primary" />
+                  {categoryLabels[model.category]}
+                </span>
+              ))}
+            </div>
           </div>
           <DialogFooter>
             <Button
@@ -193,7 +436,7 @@ export function ApiKeyManager() {
             >
               Copy key
             </Button>
-            <Button onClick={() => setModalOpen(false)}>Done</Button>
+            <Button onClick={() => setShowKeyModal(false)}>Done</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/components/layout/app-header.tsx
+++ b/components/layout/app-header.tsx
@@ -3,7 +3,9 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { signOut, useSession } from "next-auth/react";
+
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 
 const links = [
@@ -17,10 +19,13 @@ export function AppHeader() {
   const { data } = useSession();
 
   return (
-    <header className="flex h-16 items-center justify-between border-b border-border bg-background/90 px-4 backdrop-blur lg:px-6">
-      <div className="flex items-center gap-3">
-        <span className="text-base font-semibold lg:hidden">Atlas AI</span>
-        <nav className="hidden items-center gap-4 text-sm font-medium lg:flex">
+    <header className="flex h-16 items-center justify-between border-b border-border bg-background/80 px-4 backdrop-blur lg:px-6">
+      <div className="flex items-center gap-4">
+        <div className="flex items-center gap-2 rounded-full border border-border/80 bg-card/70 px-3 py-1 text-xs text-muted-foreground">
+          <span className="h-2 w-2 rounded-full bg-emerald-500" />
+          Atlas AI · Control Plane
+        </div>
+        <nav className="hidden items-center gap-4 text-sm font-medium xl:flex">
           {links.map((link) => (
             <Link
               key={link.name}
@@ -36,6 +41,22 @@ export function AppHeader() {
         </nav>
       </div>
       <div className="flex items-center gap-3">
+        <div className="hidden w-64 lg:block">
+          <Input placeholder="Search docs, playbooks, status…" className="h-9" />
+        </div>
+        <div className="hidden items-center gap-3 text-xs text-muted-foreground sm:flex">
+          <Link href="https://status.example.com" className="hover:text-foreground">
+            Status
+          </Link>
+          <span className="text-muted-foreground/40">•</span>
+          <Link href="https://atlas.example.com/docs" className="hover:text-foreground">
+            Docs
+          </Link>
+          <span className="text-muted-foreground/40">•</span>
+          <Link href="https://atlas.example.com/support" className="hover:text-foreground">
+            Support
+          </Link>
+        </div>
         <div className="hidden flex-col text-right text-xs leading-tight sm:flex">
           <span className="font-semibold text-foreground">{data?.user?.name ?? "Developer"}</span>
           <span className="text-muted-foreground">{data?.user?.email}</span>

--- a/lib/auth-secret.ts
+++ b/lib/auth-secret.ts
@@ -1,0 +1,54 @@
+const SECRET_MIN_LENGTH = 32;
+const DEFAULT_SECRET_SEED = "atlas-local-development-secret";
+
+const directSecretEnvOrder = [
+  "NEXTAUTH_SECRET",
+  "AUTH_SECRET",
+  "AUTHJS_SECRET",
+  "NEXT_PUBLIC_NEXTAUTH_SECRET",
+] as const;
+
+const derivedSecretEnvOrder = [
+  "VERCEL_DEPLOYMENT_ID",
+  "VERCEL_URL",
+  "NEXTAUTH_URL",
+] as const;
+
+function coalesceEnvValue(keys: readonly string[]) {
+  for (const key of keys) {
+    const value = process.env[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function deriveDeterministicSecret(seed: string) {
+  if (!seed) {
+    seed = DEFAULT_SECRET_SEED;
+  }
+
+  const hex = Array.from(seed, (char) =>
+    char.charCodeAt(0).toString(16).padStart(2, "0"),
+  ).join("");
+
+  if (hex.length >= SECRET_MIN_LENGTH) {
+    return hex;
+  }
+
+  const repeatCount = Math.ceil(SECRET_MIN_LENGTH / hex.length);
+  return hex.repeat(repeatCount).slice(0, SECRET_MIN_LENGTH);
+}
+
+export function resolveNextAuthSecret() {
+  const directSecret = coalesceEnvValue(directSecretEnvOrder);
+  if (directSecret) {
+    return directSecret;
+  }
+
+  const derivedSeed =
+    coalesceEnvValue(derivedSecretEnvOrder) ?? DEFAULT_SECRET_SEED;
+
+  return deriveDeterministicSecret(derivedSeed);
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -5,15 +5,28 @@ import { getServerSession } from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
 import { z } from "zod";
 
-import { prisma } from "./prisma";
+import { prisma, prismaReady, isDatabaseConfigured } from "./prisma";
+import { resolveNextAuthSecret } from "./auth-secret";
+import { getDemoUserConfig } from "./demo-user";
 
 const credentialsSchema = z.object({
   email: z.string().email({ message: "Valid email is required" }),
   password: z.string().min(6, { message: "Password is required" }),
 });
 
+const demoUserConfig = getDemoUserConfig();
+
+const resolvedAuthSecret = resolveNextAuthSecret();
+
+if (!process.env.NEXTAUTH_SECRET) {
+  process.env.NEXTAUTH_SECRET = resolvedAuthSecret;
+}
+
+await prismaReady;
+
 export const authOptions: NextAuthOptions = {
-  adapter: PrismaAdapter(prisma),
+  secret: resolvedAuthSecret,
+  adapter: isDatabaseConfigured ? PrismaAdapter(prisma) : undefined,
   session: {
     strategy: "jwt",
   },
@@ -35,6 +48,31 @@ export const authOptions: NextAuthOptions = {
         }
 
         const { email, password } = parsed.data;
+
+        if (!isDatabaseConfigured) {
+          const normalizedEmail = email.trim().toLowerCase();
+          const normalizedDemoEmail = demoUserConfig.email.trim().toLowerCase();
+
+          if (normalizedEmail !== normalizedDemoEmail) {
+            throw new Error("No user found with that email");
+          }
+
+          const passwordMatches = demoUserConfig.passwordHash
+            ? await compare(password, demoUserConfig.passwordHash)
+            : demoUserConfig.password !== null && password === demoUserConfig.password;
+
+          if (!passwordMatches) {
+            throw new Error("Invalid email or password");
+          }
+
+          return {
+            id: demoUserConfig.id,
+            email: demoUserConfig.email,
+            name: demoUserConfig.name,
+          };
+        }
+
+        await prismaReady;
 
         const user = await prisma.user.findUnique({
           where: { email },
@@ -63,7 +101,8 @@ export const authOptions: NextAuthOptions = {
       if (user) {
         token.name = user.name;
         token.email = user.email;
-      } else if (token.sub && (!token.name || !token.email)) {
+      } else if (isDatabaseConfigured && token.sub && (!token.name || !token.email)) {
+        await prismaReady;
         const dbUser = await prisma.user.findUnique({
           where: { id: token.sub },
           select: { name: true, email: true },

--- a/lib/demo-user.ts
+++ b/lib/demo-user.ts
@@ -1,0 +1,41 @@
+const DEFAULT_EMAIL = "demo@atlas.ai";
+const DEFAULT_PASSWORD = "AtlasDemo!2025";
+const DEFAULT_NAME = "Atlas Demo";
+const DEFAULT_ID = "demo-user";
+
+export type DemoUserConfig = {
+  id: string;
+  email: string;
+  name: string;
+  password: string | null;
+  passwordHash: string | null;
+};
+
+let memoizedConfig: DemoUserConfig | null = null;
+
+export function getDemoUserConfig(): DemoUserConfig {
+  if (memoizedConfig) {
+    return memoizedConfig;
+  }
+
+  const passwordHash = process.env.DEMO_USER_PASSWORD_HASH?.trim() || null;
+  const passwordFromEnv = process.env.DEMO_USER_PASSWORD?.trim();
+
+  memoizedConfig = {
+    id: process.env.DEMO_USER_ID?.trim() || DEFAULT_ID,
+    email: process.env.DEMO_USER_EMAIL?.trim() || DEFAULT_EMAIL,
+    name: process.env.DEMO_USER_NAME?.trim() || DEFAULT_NAME,
+    password: passwordFromEnv ?? (passwordHash ? null : DEFAULT_PASSWORD),
+    passwordHash,
+  };
+
+  return memoizedConfig;
+}
+
+export function getPublicDemoCredentialSummary() {
+  const { email, password, passwordHash } = getDemoUserConfig();
+  return {
+    email,
+    password: passwordHash ? null : password,
+  };
+}

--- a/lib/key-store.ts
+++ b/lib/key-store.ts
@@ -1,0 +1,79 @@
+import { randomBytes } from "crypto";
+import { promises as fs } from "fs";
+import path from "path";
+
+interface PersistedKeyRecord {
+  id: string;
+  key: string;
+  userId: string;
+  createdAt: string;
+  label?: string;
+  modelIds: string[];
+}
+
+const dataDirectory = path.join(process.cwd(), ".data");
+const storeFile = path.join(dataDirectory, "demo-api-keys.json");
+
+async function ensureStore() {
+  try {
+    await fs.mkdir(dataDirectory, { recursive: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+      throw error;
+    }
+  }
+
+  try {
+    await fs.access(storeFile);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      await fs.writeFile(storeFile, JSON.stringify({ keys: [] }, null, 2), "utf8");
+    } else {
+      throw error;
+    }
+  }
+}
+
+async function readStore(): Promise<PersistedKeyRecord[]> {
+  await ensureStore();
+  const raw = await fs.readFile(storeFile, "utf8");
+  const parsed = JSON.parse(raw) as { keys?: PersistedKeyRecord[] };
+  return Array.isArray(parsed.keys) ? parsed.keys : [];
+}
+
+async function writeStore(keys: PersistedKeyRecord[]) {
+  await ensureStore();
+  const payload = { keys };
+  await fs.writeFile(storeFile, JSON.stringify(payload, null, 2), "utf8");
+}
+
+export async function listKeysForUser(userId: string) {
+  const keys = await readStore();
+  return keys.filter((key) => key.userId === userId);
+}
+
+export async function createKeyForUser(userId: string, modelIds: string[], label?: string) {
+  const id = randomBytes(12).toString("hex");
+  const key = `sk-${randomBytes(24).toString("base64url")}`;
+  const createdAt = new Date().toISOString();
+  const record: PersistedKeyRecord = {
+    id,
+    key,
+    userId,
+    createdAt,
+    label: label?.trim() || undefined,
+    modelIds: Array.from(new Set(modelIds)),
+  };
+
+  const keys = await readStore();
+  keys.push(record);
+  await writeStore(keys);
+
+  return record;
+}
+
+export async function deleteKeyForUser(userId: string, keyId: string) {
+  const keys = await readStore();
+  const nextKeys = keys.filter((key) => !(key.userId === userId && key.id === keyId));
+  await writeStore(nextKeys);
+}

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -1,0 +1,87 @@
+export type ModelCategory = "llm" | "tts" | "image";
+
+export interface ModelDefinition {
+  id: string;
+  name: string;
+  category: ModelCategory;
+  shortDescription: string;
+  contextWindow?: number;
+  defaultUseCase: string;
+  release: string;
+  latency?: string;
+}
+
+export const modelCatalog: ModelDefinition[] = [
+  {
+    id: "atlas-llm-pro",
+    name: "Atlas LLM Pro",
+    category: "llm",
+    shortDescription: "Flagship reasoning model with 200K token context window.",
+    contextWindow: 200_000,
+    defaultUseCase: "Enterprise knowledge copilots and complex orchestration pipelines.",
+    release: "2025.03",
+    latency: "~1.8s first token",
+  },
+  {
+    id: "atlas-llm-lite",
+    name: "Atlas LLM Lite",
+    category: "llm",
+    shortDescription: "Cost optimised chat model tuned for fast support flows.",
+    contextWindow: 64_000,
+    defaultUseCase: "Customer support assistants, lightweight automations, summarisation.",
+    release: "2025.01",
+    latency: "~900ms first token",
+  },
+  {
+    id: "atlas-llm-code",
+    name: "Atlas LLM Code",
+    category: "llm",
+    shortDescription: "Code generation specialist with repository level context ingest.",
+    contextWindow: 128_000,
+    defaultUseCase: "Pair programming, migration assistance, static analysis with natural language outputs.",
+    release: "2024.12",
+    latency: "~2.2s first token",
+  },
+  {
+    id: "atlas-voice-studio",
+    name: "Atlas Voice Studio",
+    category: "tts",
+    shortDescription: "Neural TTS with expressive prosody controls and 20+ voices.",
+    defaultUseCase: "Interactive voice assistants, localisation pipelines, marketing content.",
+    release: "2025.02",
+    latency: "Streaming <250ms",
+  },
+  {
+    id: "atlas-voice-lite",
+    name: "Atlas Voice Lite",
+    category: "tts",
+    shortDescription: "Lightweight speech synthesis ideal for IVR and IoT devices.",
+    defaultUseCase: "Transaction notifications, embedded devices, accessibility cues.",
+    release: "2024.11",
+    latency: "Streaming <180ms",
+  },
+  {
+    id: "atlas-vision-diffuse",
+    name: "Atlas Vision Diffuse",
+    category: "image",
+    shortDescription: "Text-to-image diffusion tuned for photorealistic renders.",
+    defaultUseCase: "Product marketing visuals, concept art, virtual staging.",
+    release: "2025.04",
+    latency: "1.4s per frame",
+  },
+  {
+    id: "atlas-vision-illustrate",
+    name: "Atlas Vision Illustrate",
+    category: "image",
+    shortDescription: "Illustration focused diffusion with stylised control presets.",
+    defaultUseCase: "Storyboarding, editorial artwork, motion graphic frames.",
+    release: "2024.10",
+    latency: "1.1s per frame",
+  },
+];
+
+const modelMap = new Map(modelCatalog.map((model) => [model.id, model]));
+
+export function getModelById(modelId: string): ModelDefinition | undefined {
+  return modelMap.get(modelId);
+}

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,10 +1,54 @@
 import { PrismaClient } from "@prisma/client";
 
+const DATABASE_ENV_KEYS = [
+  "DATABASE_URL",
+  "POSTGRES_PRISMA_URL",
+  "POSTGRES_URL_NON_POOLING",
+  "POSTGRES_URL",
+  "SUPABASE_DB_URL",
+] as const;
+
+const PLACEHOLDER_DATABASE_URL = "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+
+type ResolvedDatabaseUrl = {
+  url: string;
+  fromEnvironment: boolean;
+};
+
+function resolveDatabaseUrl(): ResolvedDatabaseUrl {
+  for (const key of DATABASE_ENV_KEYS) {
+    const value = process.env[key]?.trim();
+    if (value) {
+      if (key !== "DATABASE_URL") {
+        process.env.DATABASE_URL = value;
+      }
+      return { url: value, fromEnvironment: true };
+    }
+  }
+
+  if (!process.env.DATABASE_URL) {
+    process.env.DATABASE_URL = PLACEHOLDER_DATABASE_URL;
+  }
+
+  return { url: process.env.DATABASE_URL, fromEnvironment: process.env.DATABASE_URL !== PLACEHOLDER_DATABASE_URL };
+}
+
+const { url: databaseUrl, fromEnvironment } = resolveDatabaseUrl();
+
 const globalForPrisma = globalThis as unknown as {
   prisma?: PrismaClient;
 };
 
-export const prisma = globalForPrisma.prisma ?? new PrismaClient();
+export const prisma = globalForPrisma.prisma ?? new PrismaClient({
+  datasources: {
+    db: {
+      url: databaseUrl,
+    },
+  },
+});
+
+export const prismaReady = Promise.resolve();
+export const isDatabaseConfigured = fromEnvironment;
 
 if (process.env.NODE_ENV !== "production") {
   globalForPrisma.prisma = prisma;

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,18 @@
-export { default } from "next-auth/middleware";
+import { withAuth } from "next-auth/middleware";
+
+import { resolveNextAuthSecret } from "./lib/auth-secret";
+
+export default withAuth({
+  secret: resolveNextAuthSecret(),
+});
 
 export const config = {
-  matcher: ["/dashboard/:path*", "/playground/:path*", "/settings/:path*", "/api/keys/:path*", "/api/playground/:path*", "/api/settings/:path*"],
+  matcher: [
+    "/dashboard/:path*",
+    "/playground/:path*",
+    "/settings/:path*",
+    "/api/keys/:path*",
+    "/api/playground/:path*",
+    "/api/settings/:path*",
+  ],
 };

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build --turbopack",
+    "build": "prisma generate && next build --turbopack",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "db:seed": "prisma db seed"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -41,5 +42,8 @@
     "prisma": "^5.22.0",
     "tailwindcss": "^3.4.14",
     "typescript": "^5"
+  },
+  "prisma": {
+    "seed": "node prisma/seed.js"
   }
 }

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -1,0 +1,38 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const { PrismaClient } = require("@prisma/client");
+const { hash } = require("bcryptjs");
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const email = process.env.DEMO_USER_EMAIL?.trim() || "demo@atlas.ai";
+  const password = process.env.DEMO_USER_PASSWORD || "AtlasDemo!2025";
+  const name = process.env.DEMO_USER_NAME?.trim() || "Atlas Demo";
+
+  const hashedPassword = await hash(password, 12);
+
+  const user = await prisma.user.upsert({
+    where: { email },
+    create: {
+      email,
+      name,
+      password: hashedPassword,
+    },
+    update: {
+      name,
+      password: hashedPassword,
+    },
+  });
+
+  console.log(`Seeded demo user ${user.email} with password "${password}".`);
+  console.log("You can update or disable the demo credentials by setting DEMO_USER_* env vars before running the seed.");
+}
+
+main()
+  .catch((error) => {
+    console.error("Failed to seed demo user", error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
- add a shared model catalog and filesystem-backed key store so API keys can be scoped to language, speech, or vision models even when Kong is unavailable
- overhaul the dashboard and header with an environment overview, model catalogue, and an upgraded API key manager that supports per-model key generation
- extend the playground and API surface with speech and image preview endpoints, multi-mode UI tabs, and clearer settings guidance when the database is not configured

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce20bb4ad8832ba7f90d62e011656a