### PR TITLE
Add bilingual theming and localized console experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 # misc
 .DS_Store
 *.pem
+.data/
 
 # debug
 npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Atlas AI Platform is a secure multi-tenant developer dashboard for provisioning 
 ## Features
 
 - 🔐 Authentication with NextAuth.js credentials provider and Prisma adapter
-- 🔑 API key lifecycle management integrated with the Kong Admin API
-- 💬 Interactive LLM playground backed by a platform-level evaluation key
-- 👤 Profile and password management with inline validation
-- 📊 Responsive dashboard with usage cards and API key table
+- 🔑 API key lifecycle management integrated with the Kong Admin API, including model-scoped keys
+- 💬 Multi-modal playground covering language, text-to-speech, and text-to-image previews
+- 👤 Profile and password management with inline validation and graceful demo-mode messaging
+- 📊 Redesigned dashboard with environment overview, model catalogue, and key analytics
 
 ## Tech Stack
 
@@ -36,11 +36,17 @@ NEXTAUTH_SECRET="generate-a-secure-secret"
 NEXT_PUBLIC_KONG_API_URL="http://localhost:8000"
 KONG_ADMIN_API_URL="http://localhost:8001"
 KONG_PLAYGROUND_KEY="replace-with-eval-api-key"
+# Optional overrides for the demo login
+# DEMO_USER_EMAIL="demo@atlas.ai"
+# DEMO_USER_PASSWORD="AtlasDemo!2025"
+# DEMO_USER_PASSWORD_HASH=""
+# DEMO_USER_NAME="Atlas Demo"
+# DEMO_USER_ID="demo-user"
 ```
 
 ## Database
 
-Run the Prisma migrations to create the authentication schema:
+Run the Prisma migrations to create the authentication schema (required for account creation and profile editing):
 
 ```bash
 npx prisma migrate deploy
@@ -50,6 +56,12 @@ Generate the Prisma client:
 
 ```bash
 npx prisma generate
+```
+
+Seed the demo login (defaults to `demo@atlas.ai` / `AtlasDemo!2025` unless `DEMO_USER_*` variables are supplied):
+
+```bash
+npm run db:seed
 ```
 
 If you are in an offline environment you can bypass engine checksum checks with `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1`.
@@ -65,25 +77,51 @@ npm run dev
 
 Visit [http://localhost:3000](http://localhost:3000) to use the application. Create an account via the sign up page, then access the dashboard, playground, and settings areas.
 
+The seeded demo credentials (`demo@atlas.ai` / `AtlasDemo!2025`) are always available after `npm run db:seed` unless you override them with `DEMO_USER_*` values.
+
+If a database connection is not configured (for example in preview deployments), the application automatically falls back to the demo credentials so you can still explore the experience. Settings will surface deployment instructions until the database connection is in place. Set `DEMO_USER_PASSWORD_HASH` if you prefer to keep the password value private—when present the login form will prompt users to obtain the password from the environment instead of displaying it inline.
+
 ## Kong Integration
 
 The application expects Kong to manage API keys via the Key Authentication plugin. The `/api/keys` API route will:
 
 1. Ensure a consumer exists for the logged-in user (using the user ID as `custom_id`).
 2. Create new key credentials via `POST /consumers/{consumer}/key-auth`.
-3. Return generated keys directly to the client without persisting them.
+3. Tag each key with the selected model scopes (`model:{id}`) so the dashboard can display access levels.
 
-Revoking a key issues `DELETE /consumers/{consumer}/key-auth/{keyId}`. The dashboard lists available keys by calling the Kong Admin API.
+Revoking a key issues `DELETE /consumers/{consumer}/key-auth/{keyId}`. The dashboard lists available keys by calling the Kong Admin API. When `KONG_ADMIN_API_URL` is not present (for example in local demos) the application falls back to a filesystem-backed store under `.data/demo-api-keys.json` so you can still exercise the UI without external dependencies.
 
 ## Testing the Playground
 
-The playground proxy (`/api/playground/chat`) forwards prompts to the public Kong gateway using the `KONG_PLAYGROUND_KEY`. This isolates evaluation traffic from production API keys.
+- `/api/playground/chat` proxies requests to the language models using `KONG_PLAYGROUND_KEY` when configured and returns explanatory responses otherwise.
+- `/api/playground/tts` generates synthetic audio previews so you can validate the UI before wiring in a production speech endpoint.
+- `/api/playground/image` produces branded SVG placeholders to illustrate prompt outputs without invoking a real diffusion service.
 
 ## Security Considerations
 
 - Full API keys are never stored in the application database.
 - All protected routes, including API endpoints, are guarded by NextAuth middleware.
 - Passwords are hashed with `bcrypt` before persistence.
+
+## Deploying on Vercel
+
+1. **Provision a Postgres database** – add the [Vercel Postgres integration](https://vercel.com/integrations/vercel-postgres) or connect an external provider such as Neon. Copy the generated `POSTGRES_PRISMA_URL`, `POSTGRES_URL`, and `POSTGRES_URL_NON_POOLING` secrets.
+2. **Configure environment variables** – in the Vercel dashboard set the following for your project:
+   - `POSTGRES_PRISMA_URL` (or `DATABASE_URL`) pointing at the production database.
+   - `POSTGRES_URL_NON_POOLING` for local CLI access (optional but recommended).
+   - `NEXTAUTH_URL` equal to your deployment URL (for example `https://your-app.vercel.app`).
+   - `NEXTAUTH_SECRET` (optional). If omitted, the application will derive a deterministic secret, but providing one lets you rotate credentials manually.
+   - `KONG_ADMIN_API_URL`, `KONG_PLAYGROUND_KEY`, and any `DEMO_USER_*` overrides you need.
+3. **Run migrations against the hosted database** – pull the Vercel environment locally and execute the migrations:
+   ```bash
+   vercel env pull .env.production.local
+   DATABASE_URL=$(grep DATABASE_URL .env.production.local | cut -d'=' -f2-) npx prisma migrate deploy
+   DATABASE_URL=$(grep DATABASE_URL .env.production.local | cut -d'=' -f2-) npm run db:seed
+   ```
+   Alternatively, use the `POSTGRES_PRISMA_URL` value directly when running the commands.
+4. **Deploy** – once the database is migrated and seeded, trigger `vercel deploy`. The existing build command (`npm run build`) already runs `prisma generate` so the Prisma Client stays in sync with cached installs.
+
+After deployment you can sign in with the seeded demo credentials and update the password from the in-app settings page.
 
 ## License
 

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -1,50 +1,263 @@
-import { ApiKeyManager } from "@/components/dashboard/api-key-manager";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import Link from "next/link";
+import { ArrowUpRight, Calendar, Filter, LinkIcon, ListChecks } from "lucide-react";
 
-const usageCards = [
-  {
-    label: "API requests",
-    value: "18,240",
-    description: "+4.2% vs last 7 days",
-  },
-  {
-    label: "Tokens used",
-    value: "2.9M",
-    description: "Capped at 10M tokens",
-  },
-  {
-    label: "Spend",
-    value: "$184.12",
-    description: "Billing resets on Oct 1",
-  },
+import { ApiKeyOverview } from "@/components/dashboard/api-key-overview";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { modelCatalog, type ModelCategory } from "@/lib/models";
+import { PageHeader } from "@/components/layout/page-header";
+import { getServerDictionary, getServerLocale } from "@/lib/i18n/server";
+import { translate } from "@/lib/i18n";
+
+const statusBreakdown = [
+  { code: "200", ratio: 86 },
+  { code: "201", ratio: 8 },
+  { code: "400", ratio: 3 },
+  { code: "401", ratio: 2 },
+  { code: "500", ratio: 1 },
 ];
 
-export default function DashboardPage() {
+export default async function DashboardPage() {
+  const locale = await getServerLocale();
+  const dictionary = await getServerDictionary(locale);
+  const t = (key: string) => translate(dictionary, key);
+
+  const usageMetrics = [
+    { label: t("dashboard.metrics.requests"), value: "42,810", delta: t("dashboard.metricsDelta.requests") },
+    { label: t("dashboard.metrics.tokens"), value: "5.4M", delta: t("dashboard.metricsDelta.tokens") },
+    { label: t("dashboard.metrics.voice"), value: "892", delta: t("dashboard.metricsDelta.voice") },
+    { label: t("dashboard.metrics.images"), value: "1,240", delta: t("dashboard.metricsDelta.images") },
+  ];
+
+  const activityLog = [
+    {
+      title: t("dashboard.activity.entries.voice.title"),
+      description: t("dashboard.activity.entries.voice.description"),
+      timestamp: t("dashboard.activity.entries.voice.time"),
+    },
+    {
+      title: t("dashboard.activity.entries.key.title"),
+      description: t("dashboard.activity.entries.key.description"),
+      timestamp: t("dashboard.activity.entries.key.time"),
+    },
+    {
+      title: t("dashboard.activity.entries.policy.title"),
+      description: t("dashboard.activity.entries.policy.description"),
+      timestamp: t("dashboard.activity.entries.policy.time"),
+    },
+  ];
+
+  const contextFormatter = new Intl.NumberFormat(locale, { notation: "compact" });
+  const categoryLabels: Record<ModelCategory, string> = {
+    llm: t("apiKeys.filters.language"),
+    tts: t("apiKeys.filters.speech"),
+    image: t("apiKeys.filters.vision"),
+  };
+
   return (
     <div className="space-y-10">
-      <section>
-        <h1 className="text-3xl font-semibold tracking-tight">Welcome back</h1>
-        <p className="mt-2 text-muted-foreground">
-          Monitor your API consumption and manage access keys for the Atlas AI platform.
-        </p>
+      <PageHeader
+        title={t("dashboard.title")}
+        description={t("dashboard.description")}
+        docsHref="/docs"
+        actions={
+          <>
+            <Button variant="outline" size="sm" className="h-9">
+              <Filter className="mr-2 h-4 w-4" /> {t("dashboard.filters")}
+            </Button>
+            <Button size="sm" className="h-9" asChild>
+              <Link href="/keys">
+                {t("dashboard.createKey")}
+                <ArrowUpRight className="ml-2 h-4 w-4" />
+              </Link>
+            </Button>
+          </>
+        }
+      />
+
+      <section className="flex flex-wrap items-center gap-3 rounded-xl border border-border bg-card/50 px-4 py-3 text-sm shadow-sm">
+        <div className="inline-flex items-center gap-2 rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-500">
+          <span className="h-2 w-2 rounded-full bg-emerald-500" /> {t("dashboard.statusPill")}
+        </div>
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <Calendar className="h-4 w-4" />
+          {t("dashboard.statusPeriod")}
+        </div>
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <ListChecks className="h-4 w-4" />
+          {t("dashboard.compliance")}
+        </div>
+        <Button variant="ghost" size="sm" className="ml-auto h-8 px-2" asChild>
+          <Link href="https://status.example.com" className="inline-flex items-center gap-1 text-xs">
+            {t("dashboard.statusHistory")}
+            <ArrowUpRight className="h-3.5 w-3.5" />
+          </Link>
+        </Button>
       </section>
 
-      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-        {usageCards.map((card) => (
-          <Card key={card.label}>
+      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        {usageMetrics.map((metric) => (
+          <Card key={metric.label} className="border-border/60 bg-card/50">
             <CardHeader className="pb-2">
-              <CardDescription>{card.label}</CardDescription>
-              <CardTitle className="text-3xl">{card.value}</CardTitle>
+              <CardDescription>{metric.label}</CardDescription>
+              <CardTitle className="text-3xl tracking-tight">{metric.value}</CardTitle>
             </CardHeader>
             <CardContent>
-              <p className="text-sm text-muted-foreground">{card.description}</p>
+              <p className="text-xs font-medium text-muted-foreground">{metric.delta}</p>
             </CardContent>
           </Card>
         ))}
       </section>
 
-      <section>
-        <ApiKeyManager />
+      <section className="grid gap-6 lg:grid-cols-3">
+        <Card className="lg:col-span-2">
+          <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <CardTitle>{t("dashboard.httpTitle")}</CardTitle>
+              <CardDescription>{t("dashboard.httpDescription")}</CardDescription>
+            </div>
+            <Button variant="ghost" size="sm" className="h-8">
+              {t("dashboard.openMetrics")}
+              <ArrowUpRight className="ml-2 h-4 w-4" />
+            </Button>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-5 gap-4">
+              {statusBreakdown.map((status) => (
+                <div key={status.code} className="flex flex-col items-center justify-end gap-2">
+                  <div className="flex h-44 w-full items-end overflow-hidden rounded-lg border border-border bg-gradient-to-t from-primary/10 via-primary/40 to-primary/80">
+                    <div style={{ height: `${status.ratio}%` }} className="w-full rounded-t-lg bg-gradient-to-t from-primary via-primary/80 to-white/80" />
+                  </div>
+                  <span className="text-sm font-semibold text-foreground">{status.code}</span>
+                  <span className="text-xs text-muted-foreground">{status.ratio}%</span>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>{t("dashboard.latencyTitle")}</CardTitle>
+            <CardDescription>{t("dashboard.latencyDescription")}</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="space-y-2">
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">{t("dashboard.p95")}</p>
+              <p className="text-3xl font-semibold text-foreground">382 ms</p>
+              <p className="text-xs text-muted-foreground">Optimised edge runtime · -12% vs previous period</p>
+            </div>
+            <div className="space-y-2">
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">{t("dashboard.availability")}</p>
+              <div className="flex items-center gap-3">
+                <div className="h-2 flex-1 rounded-full bg-emerald-500/10">
+                  <div className="h-full rounded-full bg-emerald-500" style={{ width: "99.98%" }} />
+                </div>
+                <span className="text-sm font-medium text-foreground">99.98%</span>
+              </div>
+            </div>
+            <div className="rounded-lg border border-dashed border-border/70 bg-muted/30 p-4 text-xs text-muted-foreground">
+              {t("dashboard.availabilityNote")}
+            </div>
+          </CardContent>
+        </Card>
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-2">
+        <Card className="border-border/70">
+          <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <CardTitle>{t("dashboard.apiCredentialsTitle")}</CardTitle>
+              <CardDescription>{t("dashboard.apiCredentialsDescription")}</CardDescription>
+            </div>
+            <Button variant="outline" size="sm" className="h-8" asChild>
+              <Link href="/keys">
+                {t("dashboard.manageKeys")}
+                <ArrowUpRight className="ml-2 h-4 w-4" />
+              </Link>
+            </Button>
+          </CardHeader>
+          <CardContent>
+            <ApiKeyOverview />
+          </CardContent>
+        </Card>
+        <Card className="border-border/70">
+          <CardHeader>
+            <CardTitle>{t("dashboard.activityTitle")}</CardTitle>
+            <CardDescription>{t("dashboard.activityDescription")}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {activityLog.length === 0 ? (
+              <p className="text-sm text-muted-foreground">{t("dashboard.emptyActivity")}</p>
+            ) : (
+              <ol className="space-y-4 text-sm">
+                {activityLog.map((item) => (
+                  <li key={item.title} className="flex items-start gap-3">
+                    <span className="mt-1 h-2.5 w-2.5 rounded-full bg-primary" />
+                    <div>
+                      <p className="font-medium text-foreground">{item.title}</p>
+                      <p className="text-xs text-muted-foreground">{item.description}</p>
+                      <p className="text-xs text-muted-foreground/70">{item.timestamp}</p>
+                    </div>
+                  </li>
+                ))}
+              </ol>
+            )}
+          </CardContent>
+        </Card>
+      </section>
+
+      <section className="space-y-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-semibold text-foreground">{t("dashboard.availableModelsTitle")}</h2>
+            <p className="text-sm text-muted-foreground">{t("dashboard.availableModelsDescription")}</p>
+          </div>
+          <Button variant="outline" size="sm" className="h-9" asChild>
+            <Link href="/docs">
+              {t("dashboard.integrationGuide")}
+              <LinkIcon className="ml-2 h-4 w-4" />
+            </Link>
+          </Button>
+        </div>
+        <div className="overflow-hidden rounded-xl border border-border bg-card/50">
+          <table className="min-w-full divide-y divide-border text-sm">
+            <thead className="bg-muted/50">
+              <tr>
+                <th scope="col" className="px-4 py-3 text-left font-medium text-muted-foreground">
+                  {t("dashboard.modelTable.model")}
+                </th>
+                <th scope="col" className="px-4 py-3 text-left font-medium text-muted-foreground">
+                  {t("dashboard.modelTable.modality")}
+                </th>
+                <th scope="col" className="px-4 py-3 text-left font-medium text-muted-foreground">
+                  {t("dashboard.modelTable.context")}
+                </th>
+                <th scope="col" className="px-4 py-3 text-left font-medium text-muted-foreground">
+                  {t("dashboard.modelTable.release")}
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border bg-card/40">
+              {modelCatalog.map((model) => (
+                <tr key={model.id}>
+                  <td className="px-4 py-3">
+                    <div className="space-y-1">
+                      <p className="font-medium text-foreground">{model.name}</p>
+                      <p className="text-xs text-muted-foreground">{model.shortDescription}</p>
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">{categoryLabels[model.category]}</td>
+                  <td className="px-4 py-3 text-muted-foreground">
+                    {model.contextWindow
+                      ? `${contextFormatter.format(model.contextWindow)} ${t("dashboard.modelTable.tokensLabel")}`
+                      : t("dashboard.modelTable.unknown")}
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">{model.release}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       </section>
     </div>
   );

--- a/app/(protected)/docs/page.tsx
+++ b/app/(protected)/docs/page.tsx
@@ -1,0 +1,86 @@
+import Link from "next/link";
+
+import { PageHeader } from "@/components/layout/page-header";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+const resources = [
+  {
+    title: "API reference",
+    description: "Endpoints, schemas, and examples for every Atlas capability.",
+    href: "https://atlas.example.com/docs/api",
+  },
+  {
+    title: "Quickstart",
+    description: "Spin up your first integration in less than five minutes.",
+    href: "https://atlas.example.com/docs/quickstart",
+  },
+  {
+    title: "Playground recipes",
+    description: "Prompt templates and guardrails for production-grade chat experiences.",
+    href: "https://atlas.example.com/docs/playground",
+  },
+  {
+    title: "Security hardening",
+    description: "Recommended policies for rotating keys and monitoring misuse.",
+    href: "https://atlas.example.com/docs/security",
+  },
+];
+
+const sdks = [
+  { language: "TypeScript", version: "v2.1.0", href: "https://atlas.example.com/sdk/typescript" },
+  { language: "Python", version: "v1.8.3", href: "https://atlas.example.com/sdk/python" },
+  { language: "Go", version: "v0.9.6", href: "https://atlas.example.com/sdk/go" },
+];
+
+export default function DocsPage() {
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Documentation"
+        description="Everything you need to integrate Atlas into your applications, from REST endpoints to governance policies."
+      />
+      <Card className="border-border/70 bg-card/40">
+        <CardHeader>
+          <CardTitle>Featured guides</CardTitle>
+          <CardDescription>Curated walkthroughs to get teams productive quickly.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-4 md:grid-cols-2">
+          {resources.map((resource) => (
+            <Link
+              key={resource.title}
+              href={resource.href}
+              className="group rounded-lg border border-border/50 bg-background/40 p-4 transition hover:border-primary hover:shadow-sm"
+            >
+              <p className="font-medium text-foreground group-hover:text-primary">{resource.title}</p>
+              <p className="mt-1 text-sm text-muted-foreground">{resource.description}</p>
+              <span className="mt-3 inline-flex items-center text-xs font-medium text-primary">
+                Read guide →
+              </span>
+            </Link>
+          ))}
+        </CardContent>
+      </Card>
+      <Card className="border-border/70 bg-card/40">
+        <CardHeader>
+          <CardTitle>SDK downloads</CardTitle>
+          <CardDescription>Always pinned to the latest stable release.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="grid gap-3 md:grid-cols-3">
+            {sdks.map((sdk) => (
+              <Link
+                key={sdk.language}
+                href={sdk.href}
+                className="rounded-lg border border-border/60 bg-background/40 p-4 transition hover:border-primary hover:text-primary"
+              >
+                <p className="text-sm font-semibold">{sdk.language}</p>
+                <p className="text-xs text-muted-foreground">Version {sdk.version}</p>
+              </Link>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+

--- a/app/(protected)/keys/page.tsx
+++ b/app/(protected)/keys/page.tsx
@@ -1,0 +1,28 @@
+import { ApiKeyManager } from "@/components/dashboard/api-key-manager";
+import { PageHeader } from "@/components/layout/page-header";
+import { Card, CardContent } from "@/components/ui/card";
+import { getServerDictionary, getServerLocale } from "@/lib/i18n/server";
+import { translate } from "@/lib/i18n";
+
+export default async function KeysPage() {
+  const locale = await getServerLocale();
+  const dictionary = await getServerDictionary(locale);
+  const t = (key: string) => translate(dictionary, key);
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title={t("apiKeys.heading")}
+        description={t("apiKeys.description")}
+        docsHref="/docs"
+      />
+      <Card className="border-border/70 bg-muted/30">
+        <CardContent className="space-y-2 py-5 text-sm text-muted-foreground">
+          <p>{t("apiKeys.page.reminder")}</p>
+          <p>{t("apiKeys.page.automation")}</p>
+        </CardContent>
+      </Card>
+      <ApiKeyManager />
+    </div>
+  );
+}

--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation";
 
 import { AppHeader } from "@/components/layout/app-header";
 import { AppSidebar } from "@/components/layout/app-sidebar";
+import { WorkspaceProvider } from "@/components/providers/workspace-provider";
 import { getAuthSession } from "@/lib/auth";
 
 export default async function ProtectedLayout({
@@ -16,12 +17,14 @@ export default async function ProtectedLayout({
   }
 
   return (
-    <div className="flex min-h-screen w-full bg-background">
-      <AppSidebar />
-      <div className="flex flex-1 flex-col">
-        <AppHeader />
-        <main className="flex-1 px-4 py-6 lg:px-8">{children}</main>
+    <WorkspaceProvider>
+      <div className="flex min-h-screen w-full bg-background">
+        <AppSidebar />
+        <div className="flex flex-1 flex-col">
+          <AppHeader />
+          <main className="flex-1 px-4 py-6 lg:px-8">{children}</main>
+        </div>
       </div>
-    </div>
+    </WorkspaceProvider>
   );
 }

--- a/app/(protected)/playground/page.tsx
+++ b/app/(protected)/playground/page.tsx
@@ -1,15 +1,14 @@
 import { PlaygroundPanel } from "@/components/playground/playground-panel";
+import { PageHeader } from "@/components/layout/page-header";
 
 export default function PlaygroundPage() {
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-3xl font-semibold tracking-tight">Playground</h1>
-        <p className="mt-2 max-w-2xl text-muted-foreground">
-          Experiment with the Atlas large language model using a dedicated evaluation key that does not count against your
-          production usage.
-        </p>
-      </div>
+      <PageHeader
+        title="Playground"
+        description="Evaluate Atlas language, speech, and vision models side by side before shipping to production."
+        docsHref="/docs"
+      />
       <PlaygroundPanel />
     </div>
   );

--- a/app/(protected)/projects/page.tsx
+++ b/app/(protected)/projects/page.tsx
@@ -1,0 +1,38 @@
+import { ProjectTable } from "@/components/projects/project-table";
+import { PageHeader } from "@/components/layout/page-header";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { getServerDictionary, getServerLocale } from "@/lib/i18n/server";
+import { translate } from "@/lib/i18n";
+
+export default async function ProjectsPage() {
+  const locale = await getServerLocale();
+  const dictionary = await getServerDictionary(locale);
+  const t = (key: string) => translate(dictionary, key);
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title={t("projects.title")}
+        description={t("projects.description")}
+        docsHref="/docs"
+      />
+      <Card className="border-border/70 bg-card/40">
+        <CardHeader>
+          <CardTitle>{t("projects.policiesTitle")}</CardTitle>
+          <CardDescription>{t("projects.policiesDescription")}</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-4 text-sm text-muted-foreground md:grid-cols-2">
+          <div>
+            <p className="font-medium text-foreground">{t("projects.defaultAccessTitle")}</p>
+            <p>{t("projects.defaultAccessBody")}</p>
+          </div>
+          <div>
+            <p className="font-medium text-foreground">{t("projects.lifecycleTitle")}</p>
+            <p>{t("projects.lifecycleBody")}</p>
+          </div>
+        </CardContent>
+      </Card>
+      <ProjectTable />
+    </div>
+  );
+}

--- a/app/(protected)/settings/page.tsx
+++ b/app/(protected)/settings/page.tsx
@@ -4,7 +4,8 @@ import { PasswordForm } from "@/components/settings/password-form";
 import { ProfileForm } from "@/components/settings/profile-form";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { getAuthSession } from "@/lib/auth";
-import { prisma } from "@/lib/prisma";
+import { prisma, prismaReady, isDatabaseConfigured } from "@/lib/prisma";
+import { PageHeader } from "@/components/layout/page-header";
 
 export default async function SettingsPage() {
   const session = await getAuthSession();
@@ -13,6 +14,50 @@ export default async function SettingsPage() {
     redirect("/signin");
   }
 
+  const header = (
+    <PageHeader
+      title="Account"
+      description="Manage the profile that appears across Atlas and secure your sign-in credentials."
+      docsHref="/docs"
+    />
+  );
+
+  if (!isDatabaseConfigured) {
+    return (
+      <div className="space-y-6">
+        {header}
+        <Card className="border-dashed border-border/80 bg-card/50">
+          <CardHeader>
+            <CardTitle>Database connection required</CardTitle>
+            <CardDescription>
+              Atlas is currently running in demo mode. Connect a Postgres database and run the Prisma migrations to persist user updates.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4 text-sm text-muted-foreground">
+            <ol className="list-decimal space-y-2 pl-4">
+              <li>
+                Provision a Postgres instance (Vercel Postgres, Neon, Supabase or any compatible managed provider).
+              </li>
+              <li>
+                Set <code className="rounded bg-muted px-1 py-0.5">DATABASE_URL</code> (or the Vercel Postgres secrets) for your deployment.
+              </li>
+              <li>
+                Run <code className="rounded bg-muted px-1 py-0.5">npx prisma migrate deploy</code> followed by <code className="rounded bg-muted px-1 py-0.5">npm run db:seed</code>.
+              </li>
+            </ol>
+            <p>
+              Until then, you can continue exploring the dashboard with the demo account <span className="font-medium text-foreground">{session.user.email}</span>.
+            </p>
+            <p>
+              Workspace information can still be adjusted from the <span className="font-medium text-foreground">Workspace</span> section of the sidebar.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  await prismaReady;
   const user = await prisma.user.findUnique({
     where: { id: session.user.id },
     select: { name: true, email: true },
@@ -24,10 +69,7 @@ export default async function SettingsPage() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-3xl font-semibold tracking-tight">Settings</h1>
-        <p className="mt-2 text-muted-foreground">Manage your profile information and update your password.</p>
-      </div>
+      {header}
       <div className="grid gap-6 lg:grid-cols-2">
         <Card>
           <CardHeader>

--- a/app/(protected)/workspace/page.tsx
+++ b/app/(protected)/workspace/page.tsx
@@ -1,0 +1,46 @@
+import { PageHeader } from "@/components/layout/page-header";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { WorkspacePreferences } from "@/components/settings/workspace-preferences";
+import { WorkspaceSummary } from "@/components/settings/workspace-summary";
+
+const governanceUpdates = [
+  {
+    title: "Staging hardening",
+    body: "New projects start in staging with read-only data replication.",
+  },
+  {
+    title: "Rotation cadence",
+    body: "Production API keys rotate every 30 days with automated alerts.",
+  },
+  {
+    title: "Audit exports",
+    body: "Download workspace-wide audit logs as CSV for compliance reviews.",
+  },
+];
+
+export default function WorkspacePage() {
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Workspace"
+        description="Manage organization details, govern projects, and keep your Atlas control plane aligned across teams."
+      />
+      <WorkspaceSummary />
+      <WorkspacePreferences />
+      <Card className="border-border/70 bg-muted/30">
+        <CardHeader>
+          <CardTitle>Governance playbook</CardTitle>
+          <CardDescription>Recommended steps for keeping environments production-ready.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-4 md:grid-cols-3">
+          {governanceUpdates.map((item) => (
+            <div key={item.title} className="space-y-2 rounded-lg border border-border/60 bg-background/50 p-4">
+              <p className="text-sm font-semibold text-foreground">{item.title}</p>
+              <p className="text-sm text-muted-foreground">{item.body}</p>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -2,7 +2,7 @@ import { hash } from "bcryptjs";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
-import { prisma } from "@/lib/prisma";
+import { prisma, prismaReady, isDatabaseConfigured } from "@/lib/prisma";
 
 const registerSchema = z.object({
   name: z.string().min(2, { message: "Name is required" }),
@@ -12,6 +12,13 @@ const registerSchema = z.object({
 
 export async function POST(request: Request) {
   try {
+    if (!isDatabaseConfigured) {
+      return NextResponse.json(
+        { message: "User registration is temporarily unavailable while the database connection is not configured." },
+        { status: 503 },
+      );
+    }
+    await prismaReady;
     const json = await request.json();
     const parsed = registerSchema.safeParse(json);
 

--- a/app/api/keys/[keyId]/route.ts
+++ b/app/api/keys/[keyId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { getAuthSession } from "@/lib/auth";
+import { deleteKeyForUser } from "@/lib/key-store";
 
 const adminApiUrl = process.env.KONG_ADMIN_API_URL;
 
@@ -15,11 +16,12 @@ export async function DELETE(
       return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
     }
 
-    if (!adminApiUrl) {
-      return NextResponse.json({ message: "Kong Admin API is not configured" }, { status: 500 });
-    }
-
     const { keyId } = await params;
+
+    if (!adminApiUrl) {
+      await deleteKeyForUser(session.user.id, keyId);
+      return NextResponse.json({ message: "Key revoked" });
+    }
 
     const response = await fetch(`${adminApiUrl}/consumers/${session.user.id}/key-auth/${keyId}`, {
       method: "DELETE",

--- a/app/api/keys/route.ts
+++ b/app/api/keys/route.ts
@@ -1,8 +1,72 @@
 import { NextResponse } from "next/server";
+import { z } from "zod";
 
 import { getAuthSession } from "@/lib/auth";
+import { createKeyForUser, listKeysForUser } from "@/lib/key-store";
+import { getModelById } from "@/lib/models";
 
 const adminApiUrl = process.env.KONG_ADMIN_API_URL;
+
+const createKeySchema = z.object({
+  label: z
+    .string()
+    .trim()
+    .max(80, { message: "Label must be 80 characters or fewer" })
+    .optional(),
+  modelIds: z
+    .array(z.string())
+    .nonempty({ message: "Select at least one model" })
+    .refine((ids) => ids.every((id) => getModelById(id)), {
+      message: "One or more models are not available",
+    }),
+});
+
+function encodeLabelTag(label: string) {
+  return `label:${Buffer.from(label).toString("base64url")}`;
+}
+
+function decodeLabelTag(tag: unknown) {
+  if (typeof tag !== "string" || !tag.startsWith("label:")) {
+    return undefined;
+  }
+  try {
+    return Buffer.from(tag.slice(6), "base64url").toString("utf8");
+  } catch {
+    return undefined;
+  }
+}
+
+function extractModelIdsFromTags(tags: unknown): string[] {
+  if (!Array.isArray(tags)) return [];
+  return tags
+    .filter((tag): tag is string => typeof tag === "string" && tag.startsWith("model:"))
+    .map((tag) => tag.slice(6))
+    .filter((id) => Boolean(getModelById(id)));
+}
+
+function presentKey(record: {
+  id: string;
+  key: string;
+  createdAt: string;
+  label?: string;
+  modelIds: string[];
+}) {
+  const models = record.modelIds
+    .map((id) => getModelById(id))
+    .filter((model): model is NonNullable<typeof model> => Boolean(model));
+
+  return {
+    id: record.id,
+    key: record.key,
+    createdAt: record.createdAt,
+    label: record.label ?? null,
+    models: models.map((model) => ({
+      id: model.id,
+      name: model.name,
+      category: model.category,
+    })),
+  };
+}
 
 async function ensureConsumer(userId: string) {
   if (!adminApiUrl) {
@@ -40,7 +104,8 @@ export async function GET() {
     }
 
     if (!adminApiUrl) {
-      return NextResponse.json({ message: "Kong Admin API is not configured" }, { status: 500 });
+      const keys = await listKeysForUser(session.user.id);
+      return NextResponse.json({ keys: keys.map((key) => presentKey(key)) });
     }
 
     const response = await fetch(`${adminApiUrl}/consumers/${session.user.id}/key-auth`, {
@@ -57,13 +122,19 @@ export async function GET() {
     }
 
     const payload = (await response.json()) as {
-      data?: { id: string; key: string; created_at?: number }[];
+      data?: { id: string; key: string; created_at?: number; tags?: string[] }[];
     };
-    const keys = (payload.data ?? []).map((item) => ({
-      id: item.id,
-      key: item.key,
-      createdAt: item.created_at ? new Date(item.created_at * 1000).toISOString() : new Date().toISOString(),
-    }));
+    const keys = (payload.data ?? []).map((item) => {
+      const modelIds = extractModelIdsFromTags(item.tags ?? []);
+      const label = (item.tags ?? []).map((tag) => decodeLabelTag(tag)).find(Boolean);
+      return presentKey({
+        id: item.id,
+        key: item.key,
+        createdAt: item.created_at ? new Date(item.created_at * 1000).toISOString() : new Date().toISOString(),
+        modelIds,
+        label,
+      });
+    });
 
     return NextResponse.json({ keys });
   } catch (error) {
@@ -72,7 +143,7 @@ export async function GET() {
   }
 }
 
-export async function POST() {
+export async function POST(request: Request) {
   try {
     const session = await getAuthSession();
 
@@ -80,17 +151,35 @@ export async function POST() {
       return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
     }
 
+    const json = await request.json().catch(() => null);
+    const parsed = createKeySchema.safeParse(json);
+
+    if (!parsed.success) {
+      const message = parsed.error.issues[0]?.message ?? "Invalid payload";
+      return NextResponse.json({ message }, { status: 400 });
+    }
+
+    const { label, modelIds } = parsed.data;
+    const normalizedLabel = label?.trim() ? label.trim() : undefined;
+
     if (!adminApiUrl) {
-      return NextResponse.json({ message: "Kong Admin API is not configured" }, { status: 500 });
+      const created = await createKeyForUser(session.user.id, modelIds, normalizedLabel);
+      return NextResponse.json(presentKey(created));
     }
 
     await ensureConsumer(session.user.id);
+
+    const tags = modelIds.map((id) => `model:${id}`);
+    if (normalizedLabel) {
+      tags.push(encodeLabelTag(normalizedLabel));
+    }
 
     const response = await fetch(`${adminApiUrl}/consumers/${session.user.id}/key-auth`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
+      body: JSON.stringify({ tags }),
     });
 
     if (!response.ok) {
@@ -99,12 +188,19 @@ export async function POST() {
     }
 
     const payload = await response.json();
+    const createdAt = payload.created_at
+      ? new Date(Number(payload.created_at) * 1000).toISOString()
+      : new Date().toISOString();
 
-    return NextResponse.json({
-      key: payload.key as string,
-      id: payload.id as string,
-      createdAt: payload.created_at ? new Date(payload.created_at * 1000).toISOString() : new Date().toISOString(),
-    });
+    return NextResponse.json(
+      presentKey({
+        id: payload.id as string,
+        key: payload.key as string,
+        createdAt,
+        label: normalizedLabel,
+        modelIds,
+      }),
+    );
   } catch (error) {
     console.error("Failed to create API key", error);
     return NextResponse.json({ message: "Unable to create API key" }, { status: 500 });

--- a/app/api/models/route.ts
+++ b/app/api/models/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+
+import { modelCatalog } from "@/lib/models";
+
+export async function GET() {
+  return NextResponse.json({ models: modelCatalog });
+}

--- a/app/api/playground/chat/route.ts
+++ b/app/api/playground/chat/route.ts
@@ -33,6 +33,7 @@ export async function POST(request: Request) {
     if (!gatewayUrl || !playgroundKey) {
       return NextResponse.json(
         {
+          configured: false,
           message: "Playground is not configured",
           response:
             "The platform administrator must configure the Kong gateway credentials before the playground can be used.",
@@ -67,7 +68,7 @@ export async function POST(request: Request) {
     const data = await response.json();
     const reply = data?.choices?.[0]?.message?.content ?? "The model did not return any content.";
 
-    return NextResponse.json({ response: reply });
+    return NextResponse.json({ configured: true, response: reply });
   } catch (error) {
     console.error("Playground request failed", error);
     return NextResponse.json(

--- a/app/api/playground/image/route.ts
+++ b/app/api/playground/image/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { getAuthSession } from "@/lib/auth";
+import { getModelById } from "@/lib/models";
+
+const bodySchema = z.object({
+  prompt: z.string().min(1, { message: "Enter a prompt" }).max(400, { message: "Prompt too long" }),
+  model: z.string().default("atlas-vision-diffuse"),
+  style: z.string().max(32).optional(),
+  aspectRatio: z.string().default("1:1"),
+  variations: z.coerce.number().min(1).max(4).default(2),
+});
+
+function createPlaceholderImage(prompt: string, style: string | undefined, index: number) {
+  const palette = ["#1f2937", "#0f172a", "#1e293b", "#111827"];
+  const background = palette[index % palette.length];
+  const caption = `${prompt.slice(0, 42)}${prompt.length > 42 ? "…" : ""}`;
+  const styleLine = style ? `${style}` : "Atlas Vision";
+  const svg = `<?xml version="1.0" encoding="UTF-8"?>
+  <svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+    <rect width="512" height="512" fill="${background}" rx="32" />
+    <text x="50%" y="45%" fill="#e5e7eb" font-size="24" font-family="Inter, sans-serif" text-anchor="middle">
+      ${styleLine}
+    </text>
+    <text x="50%" y="60%" fill="#94a3b8" font-size="18" font-family="Inter, sans-serif" text-anchor="middle">
+      ${caption.replace(/&/g, "&amp;")}
+    </text>
+  </svg>`;
+  return `data:image/svg+xml;base64,${Buffer.from(svg).toString("base64")}`;
+}
+
+export async function POST(request: Request) {
+  try {
+    const session = await getAuthSession();
+
+    if (!session?.user?.id) {
+      return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+    }
+
+    const json = await request.json().catch(() => null);
+    const parsed = bodySchema.safeParse(json);
+
+    if (!parsed.success) {
+      const message = parsed.error.issues[0]?.message ?? "Invalid payload";
+      return NextResponse.json({ message }, { status: 400 });
+    }
+
+    const { prompt, model, style, aspectRatio, variations } = parsed.data;
+    const resolvedModel = getModelById(model);
+
+    if (!resolvedModel || resolvedModel.category !== "image") {
+      return NextResponse.json({ message: "Selected model is not enabled for imagery" }, { status: 400 });
+    }
+
+    const gatewayUrl = process.env.NEXT_PUBLIC_KONG_API_URL;
+    const imageKey = process.env.KONG_IMAGE_KEY ?? process.env.KONG_PLAYGROUND_KEY;
+
+    const images = Array.from({ length: variations }, (_, index) => createPlaceholderImage(prompt, style, index));
+
+    if (!gatewayUrl || !imageKey) {
+      return NextResponse.json({
+        configured: false,
+        message: "Image generation is not configured. Returning design placeholders.",
+        images,
+        aspectRatio,
+      });
+    }
+
+    return NextResponse.json({
+      configured: true,
+      message: "Replace the placeholder implementation in app/api/playground/image with your production text-to-image call.",
+      images,
+      aspectRatio,
+    });
+  } catch (error) {
+    console.error("Image playground request failed", error);
+    return NextResponse.json({ message: "Unable to generate preview imagery" }, { status: 500 });
+  }
+}

--- a/app/api/playground/tts/route.ts
+++ b/app/api/playground/tts/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { getAuthSession } from "@/lib/auth";
+import { getModelById } from "@/lib/models";
+
+const bodySchema = z.object({
+  text: z.string().min(1, { message: "Provide text to synthesise" }).max(800, { message: "Keep prompts under 800 characters" }),
+  voice: z.string().min(1).max(40).default("elysian"),
+  model: z.string().default("atlas-voice-studio"),
+  format: z.enum(["mp3", "wav"]).default("wav"),
+});
+
+function generatePlaceholderWav(durationSeconds = 1.6, frequency = 440, sampleRate = 16000) {
+  const sampleCount = Math.floor(durationSeconds * sampleRate);
+  const buffer = Buffer.alloc(44 + sampleCount * 2);
+
+  buffer.write("RIFF", 0);
+  buffer.writeUInt32LE(36 + sampleCount * 2, 4);
+  buffer.write("WAVE", 8);
+  buffer.write("fmt ", 12);
+  buffer.writeUInt32LE(16, 16);
+  buffer.writeUInt16LE(1, 20);
+  buffer.writeUInt16LE(1, 22);
+  buffer.writeUInt32LE(sampleRate, 24);
+  buffer.writeUInt32LE(sampleRate * 2, 28);
+  buffer.writeUInt16LE(2, 32);
+  buffer.writeUInt16LE(16, 34);
+  buffer.write("data", 36);
+  buffer.writeUInt32LE(sampleCount * 2, 40);
+
+  for (let i = 0; i < sampleCount; i += 1) {
+    const time = i / sampleRate;
+    const amplitude = Math.sin(2 * Math.PI * frequency * time) * 0.2;
+    buffer.writeInt16LE(Math.round(amplitude * 32767), 44 + i * 2);
+  }
+
+  return `data:audio/wav;base64,${buffer.toString("base64")}`;
+}
+
+export async function POST(request: Request) {
+  try {
+    const session = await getAuthSession();
+
+    if (!session?.user?.id) {
+      return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+    }
+
+    const json = await request.json().catch(() => null);
+    const parsed = bodySchema.safeParse(json);
+
+    if (!parsed.success) {
+      const message = parsed.error.issues[0]?.message ?? "Invalid payload";
+      return NextResponse.json({ message }, { status: 400 });
+    }
+
+    const { text, voice, model, format } = parsed.data;
+    const resolvedModel = getModelById(model);
+
+    if (!resolvedModel || resolvedModel.category !== "tts") {
+      return NextResponse.json({ message: "Selected model is not enabled for speech synthesis" }, { status: 400 });
+    }
+
+    const tone = 220 + ((text.length * 13) % 220);
+    const previewAudio = generatePlaceholderWav(1.6, tone);
+
+    const gatewayUrl = process.env.NEXT_PUBLIC_KONG_API_URL;
+    const ttsKey = process.env.KONG_TTS_KEY ?? process.env.KONG_PLAYGROUND_KEY;
+
+    if (!gatewayUrl || !ttsKey) {
+      return NextResponse.json({
+        configured: false,
+        message: "TTS service is not configured. Returning a placeholder tone for preview purposes.",
+        audio: previewAudio,
+        voice,
+        model,
+        format,
+      });
+    }
+
+    // Placeholder response even when configured to avoid unexpected failures in preview environments.
+    return NextResponse.json({
+      configured: true,
+      message: "Replace the placeholder implementation in app/api/playground/tts to call your production speech endpoint.",
+      audio: previewAudio,
+      voice,
+      model,
+      format,
+    });
+  } catch (error) {
+    console.error("TTS playground request failed", error);
+    return NextResponse.json(
+      {
+        message: "Unable to process text-to-speech request",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/settings/password/route.ts
+++ b/app/api/settings/password/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 
 import { getAuthSession } from "@/lib/auth";
-import { prisma } from "@/lib/prisma";
+import { prisma, prismaReady, isDatabaseConfigured } from "@/lib/prisma";
 
 const passwordSchema = z.object({
   currentPassword: z.string().min(8),
@@ -12,6 +12,13 @@ const passwordSchema = z.object({
 
 export async function PATCH(request: Request) {
   try {
+    if (!isDatabaseConfigured) {
+      return NextResponse.json(
+        { message: "Password updates are currently unavailable because the database connection is not configured." },
+        { status: 503 },
+      );
+    }
+    await prismaReady;
     const session = await getAuthSession();
 
     if (!session?.user?.id) {

--- a/app/api/settings/profile/route.ts
+++ b/app/api/settings/profile/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 
 import { getAuthSession } from "@/lib/auth";
-import { prisma } from "@/lib/prisma";
+import { prisma, prismaReady, isDatabaseConfigured } from "@/lib/prisma";
 
 const profileSchema = z.object({
   name: z.string().min(2).max(60),
@@ -11,6 +11,13 @@ const profileSchema = z.object({
 
 export async function PATCH(request: Request) {
   try {
+    if (!isDatabaseConfigured) {
+      return NextResponse.json(
+        { message: "Profile updates are currently unavailable because the database connection is not configured." },
+        { status: 503 },
+      );
+    }
+    await prismaReady;
     const session = await getAuthSession();
 
     if (!session?.user?.id) {

--- a/app/globals.css
+++ b/app/globals.css
@@ -34,36 +34,34 @@
   --radius: 0.75rem;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: 224 71% 4%;
-    --foreground: 210 20% 98%;
+.dark {
+  --background: 224 71% 4%;
+  --foreground: 210 20% 98%;
 
-    --card: 224 71% 4%;
-    --card-foreground: 210 20% 98%;
+  --card: 224 71% 4%;
+  --card-foreground: 210 20% 98%;
 
-    --popover: 224 71% 4%;
-    --popover-foreground: 210 20% 98%;
+  --popover: 224 71% 4%;
+  --popover-foreground: 210 20% 98%;
 
-    --primary: 217 91% 60%;
-    --primary-foreground: 222 47% 11%;
+  --primary: 217 91% 60%;
+  --primary-foreground: 222 47% 11%;
 
-    --secondary: 222 47% 11%;
-    --secondary-foreground: 210 20% 98%;
+  --secondary: 222 47% 11%;
+  --secondary-foreground: 210 20% 98%;
 
-    --muted: 222 47% 11%;
-    --muted-foreground: 210 20% 65%;
+  --muted: 222 47% 11%;
+  --muted-foreground: 210 20% 65%;
 
-    --accent: 217 91% 60%;
-    --accent-foreground: 222 47% 11%;
+  --accent: 217 91% 60%;
+  --accent-foreground: 222 47% 11%;
 
-    --destructive: 0 62% 51%;
-    --destructive-foreground: 210 20% 98%;
+  --destructive: 0 62% 51%;
+  --destructive-foreground: 210 20% 98%;
 
-    --border: 217 32% 17%;
-    --input: 217 32% 17%;
-    --ring: 224 76% 48%;
-  }
+  --border: 217 32% 17%;
+  --input: 217 32% 17%;
+  --ring: 224 76% 48%;
 }
 
 * {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,53 +1,18 @@
 import type { Metadata } from "next";
-import localFont from "next/font/local";
-
+import { cookies } from "next/headers";
 import { AuthSessionProvider } from "@/components/providers/session-provider";
+import { UIProvider } from "@/components/providers/ui-provider";
+import { THEME_COOKIE, type Theme } from "@/components/providers/theme-provider";
 import { cn } from "@/lib/utils";
 import { getAuthSession } from "@/lib/auth";
+import { getServerLocale } from "@/lib/i18n/server";
+import { GeistSans } from "geist/font/sans";
+import { GeistMono } from "geist/font/mono";
 
 import "./globals.css";
 
-const geistSans = localFont({
-  src: [
-    {
-      path: "../node_modules/geist/dist/fonts/geist-sans/Geist-Regular.woff2",
-      style: "normal",
-      weight: "400",
-    },
-    {
-      path: "../node_modules/geist/dist/fonts/geist-sans/Geist-Medium.woff2",
-      style: "normal",
-      weight: "500",
-    },
-    {
-      path: "../node_modules/geist/dist/fonts/geist-sans/Geist-SemiBold.woff2",
-      style: "normal",
-      weight: "600",
-    },
-  ],
-  variable: "--font-geist-sans",
-});
-
-const geistMono = localFont({
-  src: [
-    {
-      path: "../node_modules/geist/dist/fonts/geist-mono/GeistMono-Regular.woff2",
-      style: "normal",
-      weight: "400",
-    },
-    {
-      path: "../node_modules/geist/dist/fonts/geist-mono/GeistMono-Medium.woff2",
-      style: "normal",
-      weight: "500",
-    },
-    {
-      path: "../node_modules/geist/dist/fonts/geist-mono/GeistMono-SemiBold.woff2",
-      style: "normal",
-      weight: "600",
-    },
-  ],
-  variable: "--font-geist-mono",
-});
+const geistSans = GeistSans;
+const geistMono = GeistMono;
 
 export const metadata: Metadata = {
   title: "Atlas AI Platform",
@@ -61,9 +26,13 @@ export default async function RootLayout({
   children: React.ReactNode;
 }>) {
   const session = await getAuthSession();
+  const cookieStore = await cookies();
+  const initialLocale = await getServerLocale();
+  const storedTheme = cookieStore.get(THEME_COOKIE)?.value;
+  const initialTheme: Theme = storedTheme === "light" ? "light" : "dark";
 
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang={initialLocale} suppressHydrationWarning>
       <body
         className={cn(
           "min-h-screen bg-background font-sans text-foreground antialiased",
@@ -71,7 +40,9 @@ export default async function RootLayout({
           geistMono.variable,
         )}
       >
-        <AuthSessionProvider session={session}>{children}</AuthSessionProvider>
+        <UIProvider initialLocale={initialLocale} initialTheme={initialTheme}>
+          <AuthSessionProvider session={session}>{children}</AuthSessionProvider>
+        </UIProvider>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,46 +1,37 @@
-import Link from "next/link";
+import { QuickSettings } from "@/components/layout/quick-settings";
+import { SignInForm } from "@/components/auth/sign-in-form";
+import { getServerDictionary, getServerLocale } from "@/lib/i18n/server";
+import { translate } from "@/lib/i18n";
 
-export default function Home() {
+export default async function Home() {
+  const locale = await getServerLocale();
+  const dictionary = await getServerDictionary(locale);
+  const t = (key: string) => translate(dictionary, key);
+
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-primary/10 via-background to-background px-6 py-16">
-      <div className="mx-auto flex w-full max-w-4xl flex-col items-center text-center">
-        <span className="mb-4 inline-flex items-center rounded-full bg-primary/10 px-3 py-1 text-sm font-medium text-primary">
-          Atlas AI Platform
-        </span>
-        <h1 className="text-4xl font-semibold tracking-tight sm:text-6xl">
-          Build AI-powered experiences with production-ready infrastructure.
-        </h1>
-        <p className="mt-4 max-w-2xl text-lg text-muted-foreground">
-          Manage API access, monitor usage, and experiment with our large language model from a single secure dashboard designed for developer workflows.
-        </p>
-        <div className="mt-8 flex flex-col items-center gap-3 sm:flex-row">
-          <Link
-            href="/signup"
-            className="inline-flex h-11 items-center justify-center rounded-md bg-primary px-6 text-sm font-medium text-primary-foreground shadow transition-colors hover:bg-primary/90"
-          >
-            Create a developer account
-          </Link>
-          <Link
-            href="/signin"
-            className="inline-flex h-11 items-center justify-center rounded-md border border-input px-6 text-sm font-medium text-foreground transition-colors hover:bg-muted"
-          >
-            Sign in
-          </Link>
+    <main className="relative min-h-screen overflow-hidden bg-gradient-to-br from-background via-background to-muted/60">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -left-32 top-24 h-64 w-64 rounded-full bg-primary/20 blur-3xl" />
+        <div className="absolute bottom-10 right-0 h-72 w-72 rounded-full bg-emerald-500/10 blur-3xl" />
+      </div>
+      <div className="relative z-10 flex min-h-screen flex-col">
+        <header className="flex items-center justify-between px-6 py-8">
+          <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-primary">
+            <span className="h-2 w-2 rounded-full bg-primary" />
+            {t("common.appName")}
+          </div>
+          <QuickSettings />
+        </header>
+        <div className="flex flex-1 items-center justify-center px-4 pb-16 sm:px-6">
+          <div className="w-full max-w-md space-y-8 rounded-3xl border border-border/70 bg-card/80 p-8 shadow-2xl backdrop-blur">
+            <div className="space-y-3 text-center">
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-primary/80">{t("auth.brand")}</p>
+              <h1 className="text-3xl font-semibold text-foreground">{t("auth.title")}</h1>
+              <p className="text-sm text-muted-foreground">{t("auth.subtitle")}</p>
+            </div>
+            <SignInForm showHeading={false} />
+          </div>
         </div>
-        <dl className="mt-16 grid w-full grid-cols-1 gap-6 rounded-lg border border-border bg-card p-6 text-left shadow-sm sm:grid-cols-3">
-          <div>
-            <dt className="text-sm font-medium text-muted-foreground">Latency</dt>
-            <dd className="mt-2 text-2xl font-semibold">&lt; 400ms</dd>
-          </div>
-          <div>
-            <dt className="text-sm font-medium text-muted-foreground">Global regions</dt>
-            <dd className="mt-2 text-2xl font-semibold">6+</dd>
-          </div>
-          <div>
-            <dt className="text-sm font-medium text-muted-foreground">Guaranteed uptime</dt>
-            <dd className="mt-2 text-2xl font-semibold">99.9%</dd>
-          </div>
-        </dl>
       </div>
     </main>
   );

--- a/components/auth/sign-in-form.tsx
+++ b/components/auth/sign-in-form.tsx
@@ -3,7 +3,9 @@
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { signIn } from "next-auth/react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import { Github } from "lucide-react";
+
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
@@ -11,16 +13,31 @@ import { z } from "zod";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+import { useTranslations } from "@/components/providers/locale-provider";
 
-const schema = z.object({
-  email: z.string().email({ message: "Enter a valid email" }),
-  password: z.string().min(8, { message: "Password must be at least 8 characters" }),
-});
+type FormValues = {
+  email: string;
+  password: string;
+};
 
-type FormValues = z.infer<typeof schema>;
+type SignInFormProps = {
+  tone?: "default" | "inverted";
+  className?: string;
+  showHeading?: boolean;
+};
 
-export function SignInForm() {
+export function SignInForm({ tone = "default", className, showHeading = true }: SignInFormProps) {
   const searchParams = useSearchParams();
+  const t = useTranslations();
+  const schema = useMemo(
+    () =>
+      z.object({
+        email: z.string().email({ message: t("auth.errors.email") }),
+        password: z.string().min(8, { message: t("auth.errors.password") }),
+      }),
+    [t],
+  );
   const [error, setError] = useState<string | null>(null);
   const {
     register,
@@ -38,41 +55,112 @@ export function SignInForm() {
     });
 
     if (result?.error) {
-      setError(result.error);
+      setError(t("auth.errors.generic"));
       return;
     }
 
     window.location.href = result?.url ?? "/dashboard";
   });
 
+  const labelClass = tone === "inverted" ? "text-white/80" : undefined;
+  const inputClass =
+    tone === "inverted"
+      ? "border-white/10 bg-white/5 text-white placeholder:text-white/50 focus-visible:ring-white/40 focus-visible:ring-offset-0"
+      : undefined;
+  const helperTextClass = tone === "inverted" ? "text-rose-300" : "text-destructive";
+  const footerTextClass = tone === "inverted" ? "text-white/60" : "text-muted-foreground";
+  const footerLinkClass = tone === "inverted" ? "text-primary-foreground" : "text-primary";
+  const dividerClass = tone === "inverted" ? "text-white/50" : "text-muted-foreground";
+  const oauthButtonVariant = tone === "inverted" ? "secondary" : "outline";
+
+  const handleOAuth = async (provider: "google" | "github") => {
+    setError(null);
+    const result = await signIn(provider, {
+      redirect: false,
+      callbackUrl: searchParams.get("callbackUrl") ?? "/dashboard",
+    });
+
+    if (result?.error) {
+      setError(t("auth.errors.generic"));
+      return;
+    }
+
+    if (result?.url) {
+      window.location.href = result.url;
+    }
+  };
+
   return (
-    <div className="space-y-6">
-      <div className="space-y-2 text-center">
-        <h1 className="text-2xl font-semibold">Welcome back</h1>
-        <p className="text-sm text-muted-foreground">
-          Sign in with your developer credentials to access the dashboard.
-        </p>
+    <div className={cn("space-y-6", className)}>
+      {showHeading ? (
+        <div className="space-y-2 text-center">
+          <h1 className="text-2xl font-semibold">{t("auth.welcome")}</h1>
+          <p className={cn("text-sm", tone === "inverted" ? "text-white/60" : "text-muted-foreground")}>{t("auth.description")}</p>
+        </div>
+      ) : null}
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Button
+          type="button"
+          variant={oauthButtonVariant}
+          className="w-full"
+          onClick={() => void handleOAuth("google")}
+          disabled={isSubmitting}
+        >
+          <span className="text-sm font-medium">{t("auth.google")}</span>
+        </Button>
+        <Button
+          type="button"
+          variant={oauthButtonVariant}
+          className="w-full"
+          onClick={() => void handleOAuth("github")}
+          disabled={isSubmitting}
+        >
+          <Github className="mr-2 h-4 w-4" aria-hidden="true" />
+          <span className="text-sm font-medium">{t("auth.github")}</span>
+        </Button>
+      </div>
+      <div className="flex items-center gap-3">
+        <span className="h-px flex-1 bg-border" />
+        <span className={cn("text-xs uppercase tracking-[0.3em]", dividerClass)}>{t("auth.oauthDivider")}</span>
+        <span className="h-px flex-1 bg-border" />
       </div>
       <form onSubmit={onSubmit} className="space-y-4">
         <div className="space-y-2">
-          <Label htmlFor="email">Email</Label>
-          <Input id="email" type="email" placeholder="you@example.com" autoComplete="email" {...register("email")} />
-          {errors.email ? <p className="text-sm text-destructive">{errors.email.message}</p> : null}
+          <Label htmlFor="email" className={labelClass}>
+            {t("auth.emailLabel")}
+          </Label>
+          <Input
+            id="email"
+            type="email"
+            placeholder={t("auth.emailPlaceholder")}
+            autoComplete="email"
+            className={inputClass}
+            {...register("email")}
+          />
+          {errors.email ? <p className={cn("text-sm", helperTextClass)}>{errors.email.message}</p> : null}
         </div>
         <div className="space-y-2">
-          <Label htmlFor="password">Password</Label>
-          <Input id="password" type="password" autoComplete="current-password" {...register("password")} />
-          {errors.password ? <p className="text-sm text-destructive">{errors.password.message}</p> : null}
+          <Label htmlFor="password" className={labelClass}>
+            {t("auth.passwordLabel")}
+          </Label>
+          <Input
+            id="password"
+            type="password"
+            autoComplete="current-password"
+            className={inputClass}
+            {...register("password")}
+          />
+          {errors.password ? <p className={cn("text-sm", helperTextClass)}>{errors.password.message}</p> : null}
         </div>
-        {error ? <p className="text-sm text-destructive">{error}</p> : null}
+        {error ? <p className={cn("text-sm", helperTextClass)}>{error}</p> : null}
         <Button type="submit" className="w-full" disabled={isSubmitting}>
-          {isSubmitting ? "Signing in…" : "Sign in"}
+          {isSubmitting ? t("auth.submitting") : t("auth.submit")}
         </Button>
       </form>
-      <p className="text-center text-sm text-muted-foreground">
-        Don&apos;t have an account?{" "}
-        <Link href="/signup" className="font-semibold text-primary">
-          Create one
+      <p className={cn("text-center text-sm", footerTextClass)}>
+        {t("auth.createPrompt")} {" "}
+        <Link href="/signup" className={cn("font-semibold", footerLinkClass)}>
+          {t("auth.requestAccess")}
         </Link>
       </p>
     </div>

--- a/components/dashboard/api-key-manager.tsx
+++ b/components/dashboard/api-key-manager.tsx
@@ -11,74 +11,142 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useLocale, useTranslations } from "@/components/providers/locale-provider";
+
+import type { ModelCategory } from "@/lib/models";
+import { modelCatalog } from "@/lib/models";
+
+interface ApiModel {
+  id: string;
+  name: string;
+  category: ModelCategory;
+}
 
 interface ApiKeyRecord {
   id: string;
   key: string;
   createdAt: string;
+  label: string | null;
+  models: ApiModel[];
 }
 
-const dateFormatter = new Intl.DateTimeFormat("en", {
-  month: "short",
-  day: "numeric",
-  year: "numeric",
-});
+type GeneratedKey = ApiKeyRecord;
 
 function maskKey(key: string) {
-  if (key.length <= 8) return key;
-  return `${key.slice(0, 4)}••••${key.slice(-4)}`;
+  if (key.length <= 12) return key;
+  return `${key.slice(0, 6)}••••${key.slice(-4)}`;
 }
 
 export function ApiKeyManager() {
+  const { locale } = useLocale();
+  const t = useTranslations();
+  const dateFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(locale, {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+      }),
+    [locale],
+  );
+
+  const categoryLabels: Record<ModelCategory, string> = useMemo(
+    () => ({
+      llm: t("apiKeys.filters.language"),
+      tts: t("apiKeys.filters.speech"),
+      image: t("apiKeys.filters.vision"),
+    }),
+    [t],
+  );
+
+  const filters = useMemo(
+    () => [
+      { id: "all" as const, label: t("apiKeys.filters.all") },
+      { id: "llm" as const, label: categoryLabels.llm },
+      { id: "tts" as const, label: categoryLabels.tts },
+      { id: "image" as const, label: categoryLabels.image },
+    ],
+    [categoryLabels, t],
+  );
+
   const [keys, setKeys] = useState<ApiKeyRecord[]>([]);
+  const [models, setModels] = useState<ApiModel[]>(() =>
+    modelCatalog.map((model) => ({ id: model.id, name: model.name, category: model.category })),
+  );
   const [isLoading, setIsLoading] = useState(false);
-  const [modalOpen, setModalOpen] = useState(false);
-  const [createdKey, setCreatedKey] = useState<ApiKeyRecord | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState<(typeof filters)[number]["id"]>("all");
+  const [createOpen, setCreateOpen] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [formLabel, setFormLabel] = useState("");
+  const [formModelIds, setFormModelIds] = useState<string[]>([]);
+  const [createdKey, setCreatedKey] = useState<GeneratedKey | null>(null);
+  const [showKeyModal, setShowKeyModal] = useState(false);
+
+  const loadModels = useCallback(async () => {
+    try {
+      const response = await fetch("/api/models", { cache: "no-store" });
+      if (!response.ok) {
+        throw new Error(t("apiKeys.errors.models"));
+      }
+      const data = await response.json();
+      if (Array.isArray(data.models)) {
+        setModels(
+          data.models.map((model: ApiModel) => ({
+            id: model.id,
+            name: model.name,
+            category: model.category,
+          })),
+        );
+      }
+    } catch (err) {
+      console.error(err);
+      setError(t("apiKeys.errors.models"));
+    }
+  }, [t]);
 
   const loadKeys = useCallback(async () => {
     try {
       setIsLoading(true);
       const response = await fetch("/api/keys", { cache: "no-store" });
       if (!response.ok) {
-        throw new Error("Unable to load API keys");
+        const data = await response.json().catch(() => ({ message: t("apiKeys.errors.load") }));
+        throw new Error(data?.message ?? t("apiKeys.errors.load"));
       }
       const data = await response.json();
       setKeys(Array.isArray(data.keys) ? data.keys : []);
       setError(null);
     } catch (err) {
       console.error(err);
-      setError(err instanceof Error ? err.message : "Unable to load API keys");
+      setError(err instanceof Error ? err.message : t("apiKeys.errors.load"));
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [t]);
 
   useEffect(() => {
+    void loadModels();
     void loadKeys();
-  }, [loadKeys]);
+  }, [loadModels, loadKeys]);
 
-  const handleGenerate = useCallback(async () => {
-    try {
-      setIsLoading(true);
-      const response = await fetch("/api/keys", {
-        method: "POST",
-      });
-      if (!response.ok) {
-        const data = await response.json().catch(() => ({ message: "Unable to generate key" }));
-        throw new Error(data?.message ?? "Unable to generate key");
-      }
-      const data = await response.json();
-      setCreatedKey(data);
-      setModalOpen(true);
-      await loadKeys();
-    } catch (err) {
-      console.error(err);
-      setError(err instanceof Error ? err.message : "Unable to generate key");
-    } finally {
-      setIsLoading(false);
-    }
-  }, [loadKeys]);
+  const filteredKeys = useMemo(() => {
+    if (filter === "all") return keys;
+    return keys.filter((key) => key.models.some((model) => model.category === filter));
+  }, [filter, keys]);
+
+  const summaryByCategory = useMemo(() => {
+    return keys.reduce(
+      (acc, key) => {
+        key.models.forEach((model) => {
+          acc[model.category] = (acc[model.category] ?? 0) + 1;
+        });
+        return acc;
+      },
+      {} as Record<ModelCategory, number>,
+    );
+  }, [keys]);
 
   const handleDelete = useCallback(
     async (keyId: string) => {
@@ -86,70 +154,183 @@ export function ApiKeyManager() {
         setIsLoading(true);
         const response = await fetch(`/api/keys/${keyId}`, { method: "DELETE" });
         if (!response.ok) {
-          const data = await response.json().catch(() => ({ message: "Unable to revoke key" }));
-          throw new Error(data?.message ?? "Unable to revoke key");
+          const data = await response.json().catch(() => ({ message: t("apiKeys.errors.revoke") }));
+          throw new Error(data?.message ?? t("apiKeys.errors.revoke"));
         }
         await loadKeys();
       } catch (err) {
         console.error(err);
-        setError(err instanceof Error ? err.message : "Unable to revoke key");
+        setError(err instanceof Error ? err.message : t("apiKeys.errors.revoke"));
       } finally {
         setIsLoading(false);
       }
     },
-    [loadKeys],
+    [loadKeys, t],
   );
 
-  const maskedKeys = useMemo(() => keys.map((item) => ({ ...item, displayKey: maskKey(item.key) })), [keys]);
+  const openCreateDialog = useCallback(() => {
+    setFormLabel("");
+    setFormModelIds(models.length ? [models[0].id] : []);
+    setCreateError(null);
+    setCreateOpen(true);
+  }, [models]);
+
+  const toggleModelSelection = useCallback((modelId: string) => {
+    setFormModelIds((prev) => {
+      if (prev.includes(modelId)) {
+        return prev.filter((id) => id !== modelId);
+      }
+      return [...prev, modelId];
+    });
+  }, []);
+
+  const handleGenerate = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (formModelIds.length === 0) {
+        setCreateError(t("apiKeys.dialog.error"));
+        return;
+      }
+      try {
+        setIsLoading(true);
+        setCreateError(null);
+        const response = await fetch("/api/keys", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ label: formLabel || undefined, modelIds: formModelIds }),
+        });
+        const data = await response.json().catch(() => ({ message: t("apiKeys.errors.generate") }));
+        if (!response.ok) {
+          throw new Error(data?.message ?? t("apiKeys.errors.generate"));
+        }
+        const generated: GeneratedKey = data;
+        setCreatedKey(generated);
+        setShowKeyModal(true);
+        setCreateOpen(false);
+        await loadKeys();
+      } catch (err) {
+        console.error(err);
+        setCreateError(err instanceof Error ? err.message : t("apiKeys.errors.generate"));
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [formLabel, formModelIds, loadKeys, t],
+  );
+
+  const formatModelList = useCallback(
+    (modelsForKey: ApiModel[]) => {
+      if (modelsForKey.length === 0) {
+        return t("apiKeys.list.unscoped");
+      }
+      if (modelsForKey.length === 1) {
+        return modelsForKey[0].name;
+      }
+      if (modelsForKey.length === 2) {
+        return `${modelsForKey[0].name} + ${modelsForKey[1].name}`;
+      }
+      return `${modelsForKey[0].name} +${modelsForKey.length - 1}`;
+    },
+    [t],
+  );
 
   return (
-    <div className="space-y-6">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h2 className="text-lg font-semibold">API keys</h2>
-          <p className="text-sm text-muted-foreground">
-            Generate and manage the credentials that authenticate your requests through the Atlas AI gateway.
-          </p>
-        </div>
-        <Button onClick={handleGenerate} disabled={isLoading} className="self-start">
-          + Generate new key
-        </Button>
+    <div className="space-y-8">
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        {filters
+          .filter((filterOption) => filterOption.id !== "all")
+          .map((filterOption) => (
+            <div key={filterOption.id} className="rounded-lg border border-border/60 bg-card/40 p-4 shadow-sm">
+              <p className="text-sm text-muted-foreground">{filterOption.label}</p>
+              <p className="mt-2 text-2xl font-semibold">
+                {summaryByCategory[filterOption.id as ModelCategory] ?? 0}
+              </p>
+            </div>
+          ))}
       </div>
-      {error ? (
-        <div className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
-          {error}
+
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold">{t("apiKeys.heading")}</h2>
+          <p className="text-sm text-muted-foreground">{t("apiKeys.description")}</p>
         </div>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+          <div className="inline-flex items-center gap-2 rounded-full border border-border/80 bg-card/60 px-3 py-1 text-xs text-muted-foreground">
+            <span className="h-2 w-2 rounded-full bg-emerald-500" /> {t("apiKeys.activeWorkspace")}
+          </div>
+          <Button onClick={openCreateDialog} disabled={isLoading || models.length === 0} className="sm:self-start">
+            + {t("apiKeys.create")}
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2 text-sm">
+        {filters.map((item) => (
+          <Button
+            key={item.id}
+            type="button"
+            variant={filter === item.id ? "default" : "outline"}
+            size="sm"
+            onClick={() => setFilter(item.id)}
+          >
+            {item.label}
+          </Button>
+        ))}
+      </div>
+
+      {error ? (
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">{error}</div>
       ) : null}
-      <div className="overflow-hidden rounded-md border border-border">
+
+      <div className="overflow-hidden rounded-lg border border-border">
         <table className="min-w-full divide-y divide-border text-sm">
           <thead className="bg-muted/40">
             <tr>
               <th scope="col" className="px-4 py-3 text-left font-medium text-muted-foreground">
-                Key
+                {t("apiKeys.table.label")}
               </th>
               <th scope="col" className="px-4 py-3 text-left font-medium text-muted-foreground">
-                Created
+                {t("apiKeys.table.models")}
+              </th>
+              <th scope="col" className="px-4 py-3 text-left font-medium text-muted-foreground">
+                {t("apiKeys.table.created")}
               </th>
               <th scope="col" className="px-4 py-3 text-right font-medium text-muted-foreground">
-                Actions
+                {t("apiKeys.table.actions")}
               </th>
             </tr>
           </thead>
           <tbody className="divide-y divide-border bg-card/40">
-            {maskedKeys.length === 0 ? (
+            {filteredKeys.length === 0 ? (
               <tr>
-                <td colSpan={3} className="px-4 py-8 text-center text-muted-foreground">
-                  {isLoading ? "Loading keys…" : "No keys found. Generate one to get started."}
+                <td colSpan={4} className="px-4 py-8 text-center text-muted-foreground">
+                  {isLoading ? t("apiKeys.loading") : t("apiKeys.table.empty")}
                 </td>
               </tr>
             ) : (
-              maskedKeys.map((key) => (
+              filteredKeys.map((key) => (
                 <tr key={key.id}>
-                  <td className="px-4 py-3 font-medium text-foreground">{key.displayKey}</td>
-                  <td className="px-4 py-3 text-muted-foreground">
-                    {dateFormatter.format(new Date(key.createdAt))}
+                  <td className="px-4 py-3">
+                    <div className="space-y-1">
+                      <p className="font-medium text-foreground">{key.label ?? formatModelList(key.models)}</p>
+                      <p className="font-mono text-xs text-muted-foreground">{maskKey(key.key)}</p>
+                    </div>
                   </td>
-                  <td className="px-4 py-3 text-right">
+                  <td className="px-4 py-3">
+                    <div className="flex flex-wrap gap-2">
+                      {key.models.map((model) => (
+                        <span
+                          key={model.id}
+                          className="inline-flex items-center rounded-full border border-border/70 bg-background px-2 py-0.5 text-xs text-muted-foreground"
+                        >
+                          <span className="mr-1 h-1.5 w-1.5 rounded-full bg-primary" />
+                          {categoryLabels[model.category]}
+                        </span>
+                      ))}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">{dateFormatter.format(new Date(key.createdAt))}</td>
+                  <td className="px-4 py-3">
                     <div className="flex items-center justify-end gap-2">
                       <Button
                         variant="outline"
@@ -157,10 +338,10 @@ export function ApiKeyManager() {
                         onClick={() => navigator.clipboard.writeText(key.key)}
                         disabled={isLoading}
                       >
-                        Copy
+                        {t("apiKeys.table.copy")}
                       </Button>
                       <Button variant="ghost" size="sm" onClick={() => handleDelete(key.id)} disabled={isLoading}>
-                        Revoke
+                        {t("apiKeys.table.revoke")}
                       </Button>
                     </div>
                   </td>
@@ -171,16 +352,80 @@ export function ApiKeyManager() {
         </table>
       </div>
 
-      <Dialog open={modalOpen} onOpenChange={setModalOpen}>
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>New API key generated</DialogTitle>
-            <DialogDescription>
-              This is the only time we will show you the full key. Store it securely before leaving this page.
-            </DialogDescription>
+            <DialogTitle>{t("apiKeys.dialog.title")}</DialogTitle>
+            <DialogDescription>{t("apiKeys.dialog.description")}</DialogDescription>
           </DialogHeader>
-          <div className="rounded-md border border-dashed border-primary/40 bg-primary/5 p-4 font-mono text-sm">
-            {createdKey?.key}
+          <form onSubmit={handleGenerate} className="space-y-6">
+            <div className="space-y-2">
+              <Label htmlFor="key-label">{t("apiKeys.dialog.label")}</Label>
+              <Input
+                id="key-label"
+                placeholder={t("apiKeys.dialog.labelPlaceholder")}
+                value={formLabel}
+                onChange={(event) => setFormLabel(event.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">{t("apiKeys.dialog.labelHelp")}</p>
+            </div>
+            <div className="space-y-3">
+              <Label>{t("apiKeys.dialog.modelAccess")}</Label>
+              <div className="max-h-72 space-y-2 overflow-y-auto pr-1">
+                {models.map((model) => {
+                  const isSelected = formModelIds.includes(model.id);
+                  return (
+                    <button
+                      key={model.id}
+                      type="button"
+                      onClick={() => toggleModelSelection(model.id)}
+                      className={`w-full rounded-lg border px-3 py-3 text-left transition ${
+                        isSelected
+                          ? "border-primary bg-primary/10 text-foreground"
+                          : "border-border bg-background hover:border-foreground/40"
+                      }`}
+                    >
+                      <p className="font-medium">{model.name}</p>
+                      <p className="text-xs text-muted-foreground">{categoryLabels[model.category]}</p>
+                    </button>
+                  );
+                })}
+              </div>
+              {createError ? <p className="text-sm text-destructive">{createError}</p> : null}
+            </div>
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => setCreateOpen(false)}>
+                {t("apiKeys.dialog.cancel")}
+              </Button>
+              <Button type="submit" disabled={isLoading}>
+                {isLoading ? t("apiKeys.dialog.generating") : t("apiKeys.dialog.submit")}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={showKeyModal} onOpenChange={setShowKeyModal}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t("apiKeys.generated.title")}</DialogTitle>
+            <DialogDescription>{t("apiKeys.generated.description")}</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            {createdKey?.label ? (
+              <p className="text-sm font-medium text-foreground">{createdKey.label}</p>
+            ) : null}
+            <div className="rounded-md border border-dashed border-primary/40 bg-primary/5 p-4 font-mono text-sm">
+              {createdKey?.key}
+            </div>
+            <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+              {createdKey?.models.map((model) => (
+                <span key={model.id} className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5">
+                  <span className="h-1.5 w-1.5 rounded-full bg-primary" />
+                  {categoryLabels[model.category]}
+                </span>
+              ))}
+            </div>
           </div>
           <DialogFooter>
             <Button
@@ -191,9 +436,9 @@ export function ApiKeyManager() {
                 }
               }}
             >
-              Copy key
+              {t("apiKeys.generated.copy")}
             </Button>
-            <Button onClick={() => setModalOpen(false)}>Done</Button>
+            <Button onClick={() => setShowKeyModal(false)}>{t("apiKeys.generated.close")}</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/components/dashboard/api-key-overview.tsx
+++ b/components/dashboard/api-key-overview.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+
+import type { ModelCategory } from "@/lib/models";
+import { useLocale, useTranslations } from "@/components/providers/locale-provider";
+
+interface ApiModel {
+  id: string;
+  name: string;
+  category: ModelCategory;
+}
+
+interface ApiKeyRecord {
+  id: string;
+  key: string;
+  label: string | null;
+  createdAt: string;
+  models: ApiModel[];
+}
+
+function maskKey(key: string) {
+  if (key.length <= 12) return key;
+  return `${key.slice(0, 6)}••••${key.slice(-4)}`;
+}
+
+export function ApiKeyOverview() {
+  const { locale } = useLocale();
+  const t = useTranslations();
+  const [keys, setKeys] = useState<ApiKeyRecord[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const dateFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(locale, {
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "numeric",
+      }),
+    [locale],
+  );
+
+  const categoryLabels: Record<ModelCategory, string> = useMemo(
+    () => ({
+      llm: t("apiKeys.filters.language"),
+      tts: t("apiKeys.filters.speech"),
+      image: t("apiKeys.filters.vision"),
+    }),
+    [t],
+  );
+
+  useEffect(() => {
+    const loadKeys = async () => {
+      try {
+        setIsLoading(true);
+        const response = await fetch("/api/keys", { cache: "no-store" });
+        if (!response.ok) {
+          throw new Error(t("apiKeys.errors.load"));
+        }
+        const data = await response.json();
+        setKeys(Array.isArray(data.keys) ? data.keys : []);
+        setError(null);
+      } catch (err) {
+        console.error(err);
+        setError(err instanceof Error ? err.message : t("apiKeys.errors.load"));
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    void loadKeys();
+  }, [t]);
+
+  const latestKeys = useMemo(() => {
+    return [...keys]
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+      .slice(0, 3);
+  }, [keys]);
+
+  const summary = useMemo(() => {
+    return keys.reduce(
+      (acc, key) => {
+        key.models.forEach((model) => {
+          acc[model.category] = (acc[model.category] ?? 0) + 1;
+        });
+        if (key.models.length === 0) {
+          acc.unscoped = (acc.unscoped ?? 0) + 1;
+        }
+        return acc;
+      },
+      { unscoped: 0 } as Record<string, number>,
+    );
+  }, [keys]);
+
+  return (
+    <div className="space-y-5 text-sm">
+      <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+        {Object.entries(summary)
+          .filter(([, count]) => count > 0)
+          .map(([category, count]) => (
+            <span key={category} className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background px-3 py-1">
+              <span className="h-2 w-2 rounded-full bg-primary" />
+              {category === "unscoped"
+                ? `${t("apiKeys.list.summaryUnscoped")} · ${count}`
+                : `${categoryLabels[category as ModelCategory]} · ${count}`}
+            </span>
+          ))}
+        {keys.length === 0 ? <span>{t("apiKeys.list.summaryNone")}</span> : null}
+      </div>
+
+      <div className="space-y-4">
+        {error ? (
+          <div className="rounded-md border border-destructive/40 bg-destructive/10 px-4 py-3 text-xs text-destructive">{error}</div>
+        ) : null}
+        {isLoading ? (
+          <div className="space-y-3">
+            {[0, 1, 2].map((item) => (
+              <div key={item} className="animate-pulse rounded-lg border border-border/60 bg-muted/30 p-4">
+                <div className="h-4 w-32 rounded bg-muted" />
+                <div className="mt-2 h-3 w-48 rounded bg-muted" />
+              </div>
+            ))}
+          </div>
+        ) : latestKeys.length === 0 ? (
+          <div className="rounded-lg border border-border/60 bg-muted/20 p-6 text-center text-muted-foreground">
+            {t("apiKeys.list.summaryNone")}
+          </div>
+        ) : (
+          <ul className="space-y-3">
+            {latestKeys.map((key) => (
+              <li key={key.id} className="rounded-lg border border-border/60 bg-background/40 p-4">
+                <div className="flex flex-wrap items-start justify-between gap-2">
+                  <div>
+                    <p className="font-medium text-foreground">{key.label ?? t("apiKeys.list.unscoped")}</p>
+                    <p className="font-mono text-xs text-muted-foreground">{maskKey(key.key)}</p>
+                  </div>
+                  <p className="text-xs text-muted-foreground">{dateFormatter.format(new Date(key.createdAt))}</p>
+                </div>
+                <div className="mt-3 flex flex-wrap gap-2 text-xs text-muted-foreground">
+                  {key.models.length === 0 ? (
+                    <span className="inline-flex items-center rounded-full border border-border/50 bg-muted/40 px-2 py-0.5">
+                      {t("apiKeys.list.unscoped")}
+                    </span>
+                  ) : (
+                    key.models.map((model) => (
+                      <span key={model.id} className="inline-flex items-center rounded-full border border-border/50 bg-muted/40 px-2 py-0.5">
+                        {categoryLabels[model.category]}
+                      </span>
+                    ))
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div className="rounded-lg border border-dashed border-border/70 bg-muted/20 px-4 py-3 text-xs text-muted-foreground">
+        {t("apiKeys.list.rotateNotice")} <Link href="/docs" className="font-medium text-foreground hover:underline">{t("apiKeys.list.checklist")}</Link>
+      </div>
+    </div>
+  );
+}

--- a/components/layout/app-header.tsx
+++ b/components/layout/app-header.tsx
@@ -1,48 +1,60 @@
 "use client";
 
-import Link from "next/link";
-import { usePathname } from "next/navigation";
 import { signOut, useSession } from "next-auth/react";
-import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
+import Link from "next/link";
 
-const links = [
-  { name: "Dashboard", href: "/dashboard" },
-  { name: "Playground", href: "/playground" },
-  { name: "Settings", href: "/settings" },
-];
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { WorkspaceSwitcher } from "@/components/layout/workspace-switcher";
+import { QuickSettings } from "@/components/layout/quick-settings";
+import { useTranslations } from "@/components/providers/locale-provider";
+
+import { AppMobileNav } from "./app-mobile-nav";
 
 export function AppHeader() {
-  const pathname = usePathname();
   const { data } = useSession();
+  const t = useTranslations();
 
   return (
-    <header className="flex h-16 items-center justify-between border-b border-border bg-background/90 px-4 backdrop-blur lg:px-6">
-      <div className="flex items-center gap-3">
-        <span className="text-base font-semibold lg:hidden">Atlas AI</span>
-        <nav className="hidden items-center gap-4 text-sm font-medium lg:flex">
-          {links.map((link) => (
-            <Link
-              key={link.name}
-              href={link.href}
-              className={cn(
-                "transition-colors hover:text-foreground",
-                pathname.startsWith(link.href) ? "text-foreground" : "text-muted-foreground",
-              )}
-            >
-              {link.name}
-            </Link>
-          ))}
-        </nav>
-      </div>
-      <div className="flex items-center gap-3">
-        <div className="hidden flex-col text-right text-xs leading-tight sm:flex">
-          <span className="font-semibold text-foreground">{data?.user?.name ?? "Developer"}</span>
-          <span className="text-muted-foreground">{data?.user?.email}</span>
+    <header className="border-b border-border bg-background/80 px-4 backdrop-blur lg:px-6">
+      <div className="flex h-16 items-center justify-between">
+        <div className="flex items-center gap-3 lg:gap-4">
+          <AppMobileNav />
+          <div className="flex items-center gap-2 rounded-full border border-border/80 bg-card/70 px-3 py-1 text-xs text-muted-foreground">
+            <span className="h-2 w-2 rounded-full bg-emerald-500" />
+            {t("header.console")}
+          </div>
+          <WorkspaceSwitcher className="hidden md:block" />
         </div>
-        <Button variant="outline" size="sm" onClick={() => signOut({ callbackUrl: "/" })}>
-          Sign out
-        </Button>
+        <div className="flex items-center gap-3">
+          <div className="hidden w-64 lg:block">
+            <Input placeholder={t("header.searchPlaceholder")} className="h-9" />
+          </div>
+          <div className="hidden items-center gap-3 text-xs text-muted-foreground lg:flex">
+            <Link href="https://status.example.com" className="hover:text-foreground">
+              {t("header.status")}
+            </Link>
+            <span className="text-muted-foreground/40">•</span>
+            <Link href="https://atlas.example.com/docs" className="hover:text-foreground">
+              {t("header.docs")}
+            </Link>
+            <span className="text-muted-foreground/40">•</span>
+            <Link href="https://atlas.example.com/support" className="hover:text-foreground">
+              {t("header.support")}
+            </Link>
+          </div>
+          <QuickSettings />
+          <div className="hidden flex-col text-right text-xs leading-tight sm:flex">
+            <span className="font-semibold text-foreground">{data?.user?.name ?? "Developer"}</span>
+            <span className="text-muted-foreground">{data?.user?.email}</span>
+          </div>
+          <Button variant="outline" size="sm" onClick={() => signOut({ callbackUrl: "/" })}>
+            {t("header.signOut")}
+          </Button>
+        </div>
+      </div>
+      <div className="pb-4 md:hidden">
+        <WorkspaceSwitcher compact />
       </div>
     </header>
   );

--- a/components/layout/app-mobile-nav.tsx
+++ b/components/layout/app-mobile-nav.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Menu, X } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { useWorkspace } from "@/components/providers/workspace-provider";
+
+import { useNavigationSections } from "./navigation";
+import { useTranslations } from "@/components/providers/locale-provider";
+
+export function AppMobileNav() {
+  const pathname = usePathname();
+  const { organization, project } = useWorkspace();
+  const [open, setOpen] = useState(false);
+  const t = useTranslations();
+  const navigationSections = useNavigationSections();
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="lg:hidden"
+        onClick={() => setOpen(true)}
+        aria-label={t("navigation.accessibility.open")}
+      >
+        <Menu className="h-5 w-5" aria-hidden="true" />
+      </Button>
+      {open ? (
+        <div className="fixed inset-0 z-50 flex lg:hidden">
+          <div className="h-full w-72 border-r border-border bg-background shadow-xl">
+            <div className="flex items-center justify-between border-b border-border px-5 py-4">
+              <div>
+                <p className="text-sm font-semibold text-foreground">{organization.name}</p>
+                <p className="text-xs text-muted-foreground">{project.name}</p>
+              </div>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => setOpen(false)}
+                aria-label={t("navigation.accessibility.close")}
+              >
+                <X className="h-5 w-5" aria-hidden="true" />
+              </Button>
+            </div>
+            <nav className="flex h-[calc(100%-4rem)] flex-col gap-6 overflow-y-auto px-4 py-6">
+              {navigationSections.map((section) => (
+                <div key={section.label} className="space-y-2">
+                  <p className="px-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    {section.label}
+                  </p>
+                  <div className="space-y-1">
+                    {section.items.map((item) => {
+                      const Icon = item.icon;
+                      const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`);
+                      return (
+                        <Link
+                          key={item.name}
+                          href={item.href}
+                          onClick={() => setOpen(false)}
+                          className={cn(
+                            "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                            isActive
+                              ? "bg-primary text-primary-foreground"
+                              : "text-muted-foreground hover:bg-muted hover:text-foreground",
+                          )}
+                        >
+                          <Icon className="h-4 w-4" aria-hidden="true" />
+                          <span>{item.name}</span>
+                        </Link>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+            </nav>
+          </div>
+          <button
+            type="button"
+            aria-label={t("navigation.accessibility.dismiss")}
+            className="h-full flex-1 bg-background/60 backdrop-blur-sm"
+            onClick={() => setOpen(false)}
+          />
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/components/layout/app-sidebar.tsx
+++ b/components/layout/app-sidebar.tsx
@@ -2,46 +2,68 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { LayoutDashboard, MessageSquare, Settings } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+import { useWorkspace } from "@/components/providers/workspace-provider";
 
-const navigation = [
-  { name: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
-  { name: "Playground", href: "/playground", icon: MessageSquare },
-  { name: "Settings", href: "/settings", icon: Settings },
-];
+import { useNavigationSections } from "./navigation";
+import { useTranslations } from "@/components/providers/locale-provider";
 
 export function AppSidebar() {
   const pathname = usePathname();
+  const { organization, project } = useWorkspace();
+  const t = useTranslations();
+  const navigationSections = useNavigationSections();
 
   return (
     <aside className="hidden w-64 shrink-0 border-r border-border bg-card/40 lg:flex lg:flex-col">
-      <div className="flex h-16 items-center border-b border-border px-6">
-        <span className="text-lg font-semibold">Atlas AI</span>
+      <div className="space-y-2 border-b border-border px-6 py-5">
+        <div className="flex items-start justify-between">
+          <div>
+            <p className="text-sm font-semibold text-foreground">{organization.name}</p>
+            <p className="text-xs text-muted-foreground">{project.name}</p>
+          </div>
+          <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide text-primary">
+            {organization.plan}
+          </span>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          {t("sidebar.billingContact")}: <span className="font-medium text-foreground">{organization.billingEmail}</span>
+        </p>
       </div>
-      <nav className="flex flex-1 flex-col gap-2 px-4 py-6">
-        {navigation.map((item) => {
-          const Icon = item.icon;
-          const isActive = pathname.startsWith(item.href);
-          return (
-            <Link
-              key={item.name}
-              href={item.href}
-              className={cn(
-                "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
-                isActive ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:bg-muted hover:text-foreground",
-              )}
-            >
-              <Icon className="h-4 w-4" />
-              <span>{item.name}</span>
-            </Link>
-          );
-        })}
+      <nav className="flex flex-1 flex-col gap-6 px-4 py-6">
+        {navigationSections.map((section) => (
+          <div key={section.label} className="space-y-2">
+            <p className="px-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {section.label}
+            </p>
+            <div className="space-y-1">
+              {section.items.map((item) => {
+                const Icon = item.icon;
+                const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`);
+                return (
+                  <Link
+                    key={item.name}
+                    href={item.href}
+                    className={cn(
+                      "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                      isActive
+                        ? "bg-primary text-primary-foreground"
+                        : "text-muted-foreground hover:bg-muted hover:text-foreground",
+                    )}
+                  >
+                    <Icon className="h-4 w-4" />
+                    <span>{item.name}</span>
+                  </Link>
+                );
+              })}
+            </div>
+          </div>
+        ))}
       </nav>
       <div className="px-4 pb-6">
         <div className="rounded-md border border-dashed border-border/60 px-3 py-4 text-sm text-muted-foreground">
-          Need production access? <span className="font-medium text-foreground">Contact sales</span>
+          {t("sidebar.needAccess")} <span className="font-medium text-foreground">{t("sidebar.contactSales")}</span>
         </div>
       </div>
     </aside>

--- a/components/layout/language-toggle.tsx
+++ b/components/layout/language-toggle.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { useLocale, useTranslations } from "@/components/providers/locale-provider";
+
+export function LanguageToggle() {
+  const { locale, setLocale } = useLocale();
+  const t = useTranslations();
+  const nextLocale = locale === "es" ? "en" : "es";
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      className="h-9 rounded-full border border-border/60 bg-background/70 px-4 text-xs font-medium text-muted-foreground hover:bg-muted"
+      onClick={() => setLocale(nextLocale)}
+      aria-label={t("locale.toggleLabel")}
+    >
+      <span className={locale === "es" ? "text-foreground" : "text-muted-foreground/70"}>ES</span>
+      <span className="mx-2 text-muted-foreground/60">/</span>
+      <span className={locale === "en" ? "text-foreground" : "text-muted-foreground/70"}>EN</span>
+    </Button>
+  );
+}
+

--- a/components/layout/navigation.ts
+++ b/components/layout/navigation.ts
@@ -1,0 +1,62 @@
+import { useMemo } from "react";
+import type { ComponentType, SVGProps } from "react";
+import {
+  BookOpen,
+  Building2,
+  FolderGit2,
+  Key,
+  LayoutDashboard,
+  MessageSquare,
+  Settings,
+} from "lucide-react";
+
+import { useTranslations } from "@/components/providers/locale-provider";
+
+export type NavigationIcon = ComponentType<SVGProps<SVGSVGElement>>;
+
+export interface NavigationItem {
+  name: string;
+  href: string;
+  icon: NavigationIcon;
+  description?: string;
+}
+
+export interface NavigationSection {
+  label: string;
+  items: NavigationItem[];
+}
+
+export function useNavigationSections(): NavigationSection[] {
+  const t = useTranslations();
+
+  return useMemo(
+    () => [
+      {
+        label: t("navigation.sections.overview"),
+        items: [{ name: t("navigation.items.dashboard"), href: "/dashboard", icon: LayoutDashboard }],
+      },
+      {
+        label: t("navigation.sections.workspace"),
+        items: [
+          { name: t("navigation.items.workspace"), href: "/workspace", icon: Building2 },
+          { name: t("navigation.items.projects"), href: "/projects", icon: FolderGit2 },
+        ],
+      },
+      {
+        label: t("navigation.sections.build"),
+        items: [
+          { name: t("navigation.items.playground"), href: "/playground", icon: MessageSquare },
+          { name: t("navigation.items.docs"), href: "/docs", icon: BookOpen },
+        ],
+      },
+      {
+        label: t("navigation.sections.security"),
+        items: [
+          { name: t("navigation.items.keys"), href: "/keys", icon: Key },
+          { name: t("navigation.items.account"), href: "/settings", icon: Settings },
+        ],
+      },
+    ],
+    [t],
+  );
+}

--- a/components/layout/page-header.tsx
+++ b/components/layout/page-header.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { ReactNode } from "react";
+import { ChevronRight, ExternalLink } from "lucide-react";
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import { useWorkspace } from "@/components/providers/workspace-provider";
+import { useTranslations } from "@/components/providers/locale-provider";
+import { cn } from "@/lib/utils";
+
+interface PageHeaderProps {
+  title: string;
+  description?: string;
+  className?: string;
+  actions?: ReactNode;
+  docsHref?: string;
+}
+
+export function PageHeader({ title, description, className, actions, docsHref }: PageHeaderProps) {
+  const { organization, project } = useWorkspace();
+  const t = useTranslations();
+
+  return (
+    <div className={cn("flex flex-wrap items-start justify-between gap-6", className)}>
+      <div className="space-y-3">
+        <div className="flex flex-wrap items-center gap-1 text-xs text-muted-foreground">
+          <span>{organization.name}</span>
+          <ChevronRight className="h-3 w-3" aria-hidden="true" />
+          <span>{project.name}</span>
+          <ChevronRight className="h-3 w-3" aria-hidden="true" />
+          <span className="font-medium text-foreground">{title}</span>
+        </div>
+        <div>
+          <h1 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">{title}</h1>
+          {description ? <p className="mt-2 max-w-2xl text-sm text-muted-foreground">{description}</p> : null}
+        </div>
+        {docsHref ? (
+          <Button variant="ghost" size="sm" className="h-8 w-fit px-2" asChild>
+            <Link href={docsHref} className="inline-flex items-center gap-1">
+              {t("pageHeader.viewDocs")}
+              <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+            </Link>
+          </Button>
+        ) : null}
+      </div>
+      {actions ? <div className="flex flex-wrap items-center gap-3">{actions}</div> : null}
+    </div>
+  );
+}
+

--- a/components/layout/quick-settings.tsx
+++ b/components/layout/quick-settings.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { LanguageToggle } from "@/components/layout/language-toggle";
+import { ThemeToggle } from "@/components/layout/theme-toggle";
+
+export function QuickSettings() {
+  return (
+    <div className="flex items-center gap-2">
+      <ThemeToggle />
+      <LanguageToggle />
+    </div>
+  );
+}
+

--- a/components/layout/theme-toggle.tsx
+++ b/components/layout/theme-toggle.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Moon, Sun } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { useTheme } from "@/components/providers/theme-provider";
+import { useTranslations } from "@/components/providers/locale-provider";
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+  const t = useTranslations();
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className="h-9 w-9 rounded-full border border-border/60 bg-background/70 text-muted-foreground hover:bg-muted"
+      onClick={toggleTheme}
+      aria-label={t("theme.toggleLabel")}
+    >
+      {theme === "dark" ? <Sun className="h-4 w-4" aria-hidden="true" /> : <Moon className="h-4 w-4" aria-hidden="true" />}
+      <span className="sr-only">{t("theme.toggleLabel")}</span>
+    </Button>
+  );
+}
+

--- a/components/layout/workspace-switcher.tsx
+++ b/components/layout/workspace-switcher.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { ChevronDown } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { useWorkspace } from "@/components/providers/workspace-provider";
+
+interface WorkspaceSwitcherProps {
+  className?: string;
+  compact?: boolean;
+}
+
+export function WorkspaceSwitcher({ className, compact = false }: WorkspaceSwitcherProps) {
+  const { organizations, organization, project, selectOrganization, selectProject } = useWorkspace();
+
+  return (
+    <div className={cn("min-w-[220px] space-y-1", className)}>
+      <p className="text-[10px] uppercase tracking-widest text-muted-foreground">Workspace context</p>
+      <div className={cn("flex flex-wrap items-center gap-2", compact ? "text-xs" : "text-sm")}
+      >
+        <div className="relative">
+          <select
+            className={cn(
+              "appearance-none rounded-md border border-border bg-background px-3 py-1 pr-8 font-medium text-foreground shadow-sm",
+              compact ? "text-xs" : "text-sm",
+            )}
+            value={organization.id}
+            onChange={(event) => selectOrganization(event.target.value)}
+          >
+            {organizations.map((item) => (
+              <option key={item.id} value={item.id}>
+                {item.name}
+              </option>
+            ))}
+          </select>
+          <ChevronDown className="pointer-events-none absolute right-2 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        </div>
+        <span className="text-muted-foreground">/</span>
+        <div className="relative">
+          <select
+            className={cn(
+              "appearance-none rounded-md border border-border bg-background px-3 py-1 pr-8 font-medium text-foreground shadow-sm",
+              compact ? "text-xs" : "text-sm",
+            )}
+            value={project.id}
+            onChange={(event) => selectProject(event.target.value)}
+          >
+            {organization.projects.map((item) => (
+              <option key={item.id} value={item.id}>
+                {item.name}
+              </option>
+            ))}
+          </select>
+          <ChevronDown className="pointer-events-none absolute right-2 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        </div>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        {organization.plan} plan · {project.region.toUpperCase()} region
+      </p>
+    </div>
+  );
+}
+

--- a/components/projects/project-table.tsx
+++ b/components/projects/project-table.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useWorkspace } from "@/components/providers/workspace-provider";
+import { useLocale, useTranslations } from "@/components/providers/locale-provider";
+
+const regionCodes = ["iad1", "sfo3", "fra1", "sin1"] as const;
+type RegionCode = (typeof regionCodes)[number];
+
+export function ProjectTable() {
+  const { locale } = useLocale();
+  const t = useTranslations();
+  const { organization, project, addProject, selectProject, updateProject } = useWorkspace();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [region, setRegion] = useState<RegionCode>("iad1");
+  const [slug, setSlug] = useState("");
+  const [description, setDescription] = useState("");
+
+  const availableRegions = useMemo(
+    () =>
+      regionCodes.map((code) => ({
+        value: code,
+        label: t(`projects.regions.${code}` as const),
+      })),
+    [t],
+  );
+
+  const statusLabels = useMemo(
+    () => ({
+      Active: t("projects.status.active"),
+      "In review": t("projects.status.review"),
+      Paused: t("projects.status.paused"),
+    }),
+    [t],
+  );
+
+  useEffect(() => {
+    setSlug(
+      name
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/(^-|-$)+/g, ""),
+    );
+  }, [name]);
+
+  useEffect(() => {
+    setRegion(availableRegions[0]?.value ?? "iad1");
+  }, [availableRegions]);
+
+  const projects = useMemo(() => organization.projects, [organization.projects]);
+
+  const handleCreateProject = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!name.trim()) return;
+
+    const created = addProject(organization.id, {
+      name: name.trim(),
+      slug: slug || name.trim().toLowerCase().replace(/\s+/g, "-"),
+      region,
+      status: "Active",
+      description: description.trim() || undefined,
+    });
+
+    if (created) {
+      setDialogOpen(false);
+      setName("");
+      setSlug("");
+      setDescription("");
+      setRegion(availableRegions[0]?.value ?? "iad1");
+    }
+  };
+
+  const handleDescriptionBlur = (projectId: string, value: string) => {
+    updateProject(organization.id, projectId, { description: value.trim() || undefined });
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-sm text-muted-foreground">{t("projects.table.intro")}</p>
+        </div>
+        <Button size="sm" onClick={() => setDialogOpen(true)}>
+          + {t("projects.dialog.submit")}
+        </Button>
+      </div>
+
+      <div className="overflow-hidden rounded-xl border border-border bg-card/40">
+        <table className="min-w-full divide-y divide-border text-sm">
+          <thead className="bg-muted/40">
+            <tr>
+              <th scope="col" className="px-4 py-3 text-left font-medium text-muted-foreground">
+                {t("projects.table.name")}
+              </th>
+              <th scope="col" className="px-4 py-3 text-left font-medium text-muted-foreground">
+                {t("projects.table.region")}
+              </th>
+              <th scope="col" className="px-4 py-3 text-left font-medium text-muted-foreground">
+                {t("projects.table.status")}
+              </th>
+              <th scope="col" className="px-4 py-3 text-left font-medium text-muted-foreground">
+                {t("projects.table.created")}
+              </th>
+              <th scope="col" className="px-4 py-3 text-right font-medium text-muted-foreground">
+                {t("projects.table.actions")}
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border bg-background/40">
+            {projects.map((item) => (
+              <tr key={item.id}>
+                <td className="px-4 py-3">
+                  <div className="space-y-1">
+                    <p className="font-medium text-foreground">{item.name}</p>
+                    <input
+                      defaultValue={item.description ?? t("projects.table.placeholder")}
+                      onBlur={(event) => handleDescriptionBlur(item.id, event.target.value)}
+                      className="w-full bg-transparent text-xs text-muted-foreground focus:outline-none focus:ring-0"
+                    />
+                  </div>
+                </td>
+                <td className="px-4 py-3 text-muted-foreground">{item.region.toUpperCase()}</td>
+                <td className="px-4 py-3 text-muted-foreground">{statusLabels[item.status]}</td>
+                <td className="px-4 py-3 text-muted-foreground">
+                  {new Date(item.createdAt).toLocaleDateString(locale, { month: "short", day: "numeric", year: "numeric" })}
+                </td>
+                <td className="px-4 py-3">
+                  <div className="flex items-center justify-end gap-2">
+                    <Button
+                      variant={project.id === item.id ? "default" : "outline"}
+                      size="sm"
+                      onClick={() => selectProject(item.id)}
+                    >
+                      {project.id === item.id ? t("projects.table.active") : t("projects.table.setActive")}
+                    </Button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t("projects.dialog.title")}</DialogTitle>
+            <DialogDescription>{t("projects.dialog.body")}</DialogDescription>
+          </DialogHeader>
+          <form onSubmit={handleCreateProject} className="space-y-6">
+            <div className="space-y-2">
+              <Label htmlFor="project-name">{t("projects.dialog.name")}</Label>
+              <Input
+                id="project-name"
+                placeholder={t("projects.dialog.namePlaceholder")}
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="project-slug">{t("projects.dialog.slug")}</Label>
+              <Input
+                id="project-slug"
+                placeholder={t("projects.dialog.slugPlaceholder")}
+                value={slug}
+                onChange={(event) => setSlug(event.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="project-region">{t("projects.dialog.region")}</Label>
+              <select
+                id="project-region"
+                className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+                value={region}
+                onChange={(event) => setRegion(event.target.value as RegionCode)}
+              >
+                {availableRegions.map((item) => (
+                  <option key={item.value} value={item.value}>
+                    {item.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="project-description">{t("projects.dialog.descriptionLabel")}</Label>
+              <Input
+                id="project-description"
+                placeholder={t("projects.dialog.descriptionPlaceholder")}
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+              />
+            </div>
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => setDialogOpen(false)}>
+                {t("projects.dialog.cancel")}
+              </Button>
+              <Button type="submit">{t("projects.dialog.submit")}</Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/components/providers/locale-provider.tsx
+++ b/components/providers/locale-provider.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+
+import { dictionaries, getDictionary, isLocale, type Locale, translate } from "@/lib/i18n";
+
+export interface LocaleContextValue {
+  locale: Locale;
+  setLocale: (locale: Locale) => void;
+  t: (key: string) => string;
+}
+
+const LocaleContext = createContext<LocaleContextValue | undefined>(undefined);
+
+const LOCALE_STORAGE_KEY = "ui-locale";
+export const LOCALE_COOKIE = "ui-locale";
+
+interface LocaleProviderProps {
+  initialLocale: Locale;
+  children: React.ReactNode;
+}
+
+export function LocaleProvider({ initialLocale, children }: LocaleProviderProps) {
+  const [locale, setLocaleState] = useState<Locale>(initialLocale);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const stored = window.localStorage.getItem(LOCALE_STORAGE_KEY);
+    if (isLocale(stored)) {
+      setLocaleState(stored);
+      document.documentElement.lang = stored;
+      return;
+    }
+    document.documentElement.lang = initialLocale;
+  }, [initialLocale]);
+
+  const setLocale = useCallback(
+    (value: Locale) => {
+      setLocaleState((current) => {
+        if (current === value) {
+          return current;
+        }
+        return value;
+      });
+      document.documentElement.lang = value;
+      try {
+        window.localStorage.setItem(LOCALE_STORAGE_KEY, value);
+      } catch (error) {
+        console.warn("Unable to persist locale in localStorage", error);
+      }
+      document.cookie = `${LOCALE_COOKIE}=${value}; path=/; max-age=${60 * 60 * 24 * 365}`;
+      window.location.reload();
+    },
+    [],
+  );
+
+  const translateFn = useCallback(
+    (key: string) => {
+      const dictionary = getDictionary(locale);
+      return translate(dictionary, key);
+    },
+    [locale],
+  );
+
+  const value = useMemo<LocaleContextValue>(
+    () => ({
+      locale,
+      setLocale,
+      t: translateFn,
+    }),
+    [locale, setLocale, translateFn],
+  );
+
+  return <LocaleContext.Provider value={value}>{children}</LocaleContext.Provider>;
+}
+
+export function useLocale() {
+  const context = useContext(LocaleContext);
+  if (!context) {
+    throw new Error("useLocale must be used within a LocaleProvider");
+  }
+  return context;
+}
+
+export function useTranslations() {
+  const { t } = useLocale();
+  return t;
+}
+
+export { dictionaries };
+

--- a/components/providers/theme-provider.tsx
+++ b/components/providers/theme-provider.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+
+export type Theme = "light" | "dark";
+
+interface ThemeContextValue {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+const THEME_STORAGE_KEY = "ui-theme";
+const THEME_COOKIE = "ui-theme";
+
+function applyTheme(theme: Theme) {
+  if (typeof document === "undefined") return;
+  const root = document.documentElement;
+  if (theme === "dark") {
+    root.classList.add("dark");
+  } else {
+    root.classList.remove("dark");
+  }
+  root.setAttribute("data-theme", theme);
+}
+
+function persistTheme(theme: Theme) {
+  if (typeof document === "undefined") return;
+  try {
+    window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+  } catch (error) {
+    console.warn("Unable to persist theme in localStorage", error);
+  }
+
+  document.cookie = `${THEME_COOKIE}=${theme}; path=/; max-age=${60 * 60 * 24 * 365}`;
+}
+
+interface ThemeProviderProps {
+  initialTheme: Theme;
+  children: React.ReactNode;
+}
+
+export function ThemeProvider({ initialTheme, children }: ThemeProviderProps) {
+  const [theme, setThemeState] = useState<Theme>(initialTheme);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+    if (stored === "light" || stored === "dark") {
+      setThemeState(stored);
+      applyTheme(stored);
+      return;
+    }
+    applyTheme(initialTheme);
+  }, [initialTheme]);
+
+  useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  const setTheme = useCallback((value: Theme) => {
+    setThemeState(value);
+    persistTheme(value);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setThemeState((current) => {
+      const next = current === "dark" ? "light" : "dark";
+      persistTheme(next);
+      return next;
+    });
+  }, []);
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({ theme, setTheme, toggleTheme }),
+    [setTheme, theme, toggleTheme],
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return context;
+}
+
+export { THEME_COOKIE };
+

--- a/components/providers/ui-provider.tsx
+++ b/components/providers/ui-provider.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { LocaleProvider } from "@/components/providers/locale-provider";
+import { ThemeProvider, type Theme } from "@/components/providers/theme-provider";
+import type { Locale } from "@/lib/i18n";
+
+interface UIProviderProps {
+  initialLocale: Locale;
+  initialTheme: Theme;
+  children: React.ReactNode;
+}
+
+export function UIProvider({ initialLocale, initialTheme, children }: UIProviderProps) {
+  return (
+    <ThemeProvider initialTheme={initialTheme}>
+      <LocaleProvider initialLocale={initialLocale}>{children}</LocaleProvider>
+    </ThemeProvider>
+  );
+}
+

--- a/components/providers/workspace-provider.tsx
+++ b/components/providers/workspace-provider.tsx
@@ -1,0 +1,303 @@
+"use client";
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+
+type WorkspaceProject = {
+  id: string;
+  name: string;
+  slug: string;
+  region: string;
+  status: "Active" | "In review" | "Paused";
+  createdAt: string;
+  description?: string;
+};
+
+type WorkspaceOrganization = {
+  id: string;
+  name: string;
+  plan: "Starter" | "Pro" | "Enterprise";
+  billingEmail: string;
+  createdAt: string;
+  projects: WorkspaceProject[];
+};
+
+type WorkspaceProjectInput = {
+  name: string;
+  slug: string;
+  region: string;
+  status?: WorkspaceProject["status"];
+  description?: string;
+};
+
+type WorkspaceUpdate = Partial<Pick<WorkspaceOrganization, "name" | "billingEmail" | "plan" >>;
+
+type WorkspaceContextValue = {
+  organizations: WorkspaceOrganization[];
+  organization: WorkspaceOrganization;
+  project: WorkspaceProject;
+  selectOrganization: (organizationId: string) => void;
+  selectProject: (projectId: string) => void;
+  addProject: (organizationId: string, project: WorkspaceProjectInput) => WorkspaceProject;
+  updateOrganization: (organizationId: string, updates: WorkspaceUpdate) => void;
+  updateProject: (organizationId: string, projectId: string, updates: Partial<Omit<WorkspaceProject, "id" | "createdAt">>) => void;
+};
+
+const STORAGE_KEY = "atlas-workspace-state";
+
+const defaultOrganizations: WorkspaceOrganization[] = [
+  {
+    id: "personal",
+    name: "Personal",
+    plan: "Starter",
+    billingEmail: "demo@atlas.ai",
+    createdAt: "2024-01-12T09:00:00.000Z",
+    projects: [
+      {
+        id: "default",
+        name: "Default Project",
+        slug: "default-project",
+        region: "iad1",
+        status: "Active",
+        createdAt: "2024-01-12T09:00:00.000Z",
+        description: "Initial sandbox connected to the Atlas API with limited quotas.",
+      },
+      {
+        id: "voice-prototype",
+        name: "Voice Prototype",
+        slug: "voice-prototype",
+        region: "fra1",
+        status: "In review",
+        createdAt: "2024-05-21T14:24:00.000Z",
+        description: "Testing streaming speech synthesis for concierge workflows.",
+      },
+    ],
+  },
+  {
+    id: "atlas-labs",
+    name: "Atlas Labs",
+    plan: "Enterprise",
+    billingEmail: "platform@atlas.ai",
+    createdAt: "2023-09-05T12:00:00.000Z",
+    projects: [
+      {
+        id: "support-assistant",
+        name: "Customer Support Assistant",
+        slug: "support-assistant",
+        region: "iad1",
+        status: "Active",
+        createdAt: "2023-10-01T08:12:00.000Z",
+        description: "Production deployment serving multi-lingual support flows.",
+      },
+      {
+        id: "image-research",
+        name: "Image Research",
+        slug: "image-research",
+        region: "sfo3",
+        status: "Paused",
+        createdAt: "2024-03-18T11:45:00.000Z",
+        description: "Internal testing environment for diffusion fine-tuning.",
+      },
+    ],
+  },
+];
+
+interface StoredState {
+  organizationId: string;
+  projectId: string;
+  organizations: WorkspaceOrganization[];
+}
+
+const WorkspaceContext = createContext<WorkspaceContextValue | null>(null);
+
+function generateId() {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2, 10);
+}
+
+export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
+  const [state, setState] = useState<StoredState>(() => ({
+    organizationId: defaultOrganizations[0].id,
+    projectId: defaultOrganizations[0].projects[0].id,
+    organizations: defaultOrganizations,
+  }));
+  const [isHydrated, setIsHydrated] = useState(false);
+
+  useEffect(() => {
+    try {
+      const storedValue = window.localStorage.getItem(STORAGE_KEY);
+      if (storedValue) {
+        const parsed = JSON.parse(storedValue) as Partial<StoredState>;
+        if (parsed && Array.isArray(parsed.organizations) && parsed.organizations.length > 0) {
+          setState({
+            organizationId: parsed.organizationId ?? parsed.organizations[0].id,
+            projectId:
+              parsed.projectId ??
+              parsed.organizations[0]?.projects[0]?.id ?? defaultOrganizations[0].projects[0].id,
+            organizations: parsed.organizations,
+          });
+          setIsHydrated(true);
+          return;
+        }
+      }
+    } catch (error) {
+      console.error("Failed to load workspace state", error);
+    }
+    setIsHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isHydrated) return;
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } catch (error) {
+      console.error("Failed to persist workspace state", error);
+    }
+  }, [state, isHydrated]);
+
+  const organization = useMemo(() => {
+    return (
+      state.organizations.find((item) => item.id === state.organizationId) ?? state.organizations[0]
+    );
+  }, [state.organizations, state.organizationId]);
+
+  const project = useMemo(() => {
+    const currentOrganization = organization ?? state.organizations[0];
+    return (
+      currentOrganization?.projects.find((item) => item.id === state.projectId) ??
+      currentOrganization?.projects[0] ??
+      state.organizations[0].projects[0]
+    );
+  }, [organization, state.organizations, state.projectId]);
+
+  const selectOrganization = useCallback((organizationId: string) => {
+    setState((previous) => {
+      const nextOrganization =
+        previous.organizations.find((item) => item.id === organizationId) ?? previous.organizations[0];
+      const nextProject =
+        nextOrganization.projects.find((item) => item.id === previous.projectId) ??
+        nextOrganization.projects[0] ??
+        previous.projectId
+          ? previous.organizations
+              .flatMap((org) => org.projects)
+              .find((project) => project.id === previous.projectId) ?? nextOrganization.projects[0]
+          : nextOrganization.projects[0];
+      return {
+        organizationId: nextOrganization.id,
+        projectId: nextProject ? nextProject.id : nextOrganization.projects[0]?.id ?? previous.projectId,
+        organizations: previous.organizations,
+      };
+    });
+  }, []);
+
+  const selectProject = useCallback((projectId: string) => {
+    setState((previous) => {
+      const currentOrganization =
+        previous.organizations.find((org) => org.id === previous.organizationId) ?? previous.organizations[0];
+      const projectExists = currentOrganization.projects.some((project) => project.id === projectId);
+      return {
+        ...previous,
+        projectId: projectExists ? projectId : currentOrganization.projects[0]?.id ?? previous.projectId,
+      };
+    });
+  }, []);
+
+  const addProject = useCallback(
+    (organizationId: string, projectInput: WorkspaceProjectInput): WorkspaceProject => {
+      const newProject: WorkspaceProject = {
+        id: generateId(),
+        name: projectInput.name,
+        slug: projectInput.slug,
+        region: projectInput.region,
+        status: projectInput.status ?? "Active",
+        description: projectInput.description,
+        createdAt: new Date().toISOString(),
+      };
+
+      setState((previous) => {
+        const organizations = previous.organizations.map((org) => {
+          if (org.id !== organizationId) return org;
+          return {
+            ...org,
+            projects: [...org.projects, newProject],
+          };
+        });
+        const isCurrentOrg = previous.organizationId === organizationId;
+        return {
+          organizationId: previous.organizationId,
+          projectId: isCurrentOrg ? newProject.id : previous.projectId,
+          organizations,
+        };
+      });
+
+      return newProject;
+    },
+    [],
+  );
+
+  const updateOrganization = useCallback((organizationId: string, updates: WorkspaceUpdate) => {
+    setState((previous) => ({
+      ...previous,
+      organizations: previous.organizations.map((org) =>
+        org.id === organizationId
+          ? {
+              ...org,
+              ...updates,
+            }
+          : org,
+      ),
+    }));
+  }, []);
+
+  const updateProject = useCallback(
+    (
+      organizationId: string,
+      projectId: string,
+      updates: Partial<Omit<WorkspaceProject, "id" | "createdAt">>,
+    ) => {
+      setState((previous) => ({
+        ...previous,
+        organizations: previous.organizations.map((org) => {
+          if (org.id !== organizationId) return org;
+          return {
+            ...org,
+            projects: org.projects.map((project) =>
+              project.id === projectId
+                ? {
+                    ...project,
+                    ...updates,
+                  }
+                : project,
+            ),
+          };
+        }),
+      }));
+    },
+    [],
+  );
+
+  const value = useMemo<WorkspaceContextValue>(() => {
+    return {
+      organizations: state.organizations,
+      organization,
+      project,
+      selectOrganization,
+      selectProject,
+      addProject,
+      updateOrganization,
+      updateProject,
+    };
+  }, [state.organizations, organization, project, selectOrganization, selectProject, addProject, updateOrganization, updateProject]);
+
+  return <WorkspaceContext.Provider value={value}>{children}</WorkspaceContext.Provider>;
+}
+
+export function useWorkspace() {
+  const context = useContext(WorkspaceContext);
+  if (!context) {
+    throw new Error("useWorkspace must be used within a WorkspaceProvider");
+  }
+  return context;
+}
+

--- a/components/settings/workspace-preferences.tsx
+++ b/components/settings/workspace-preferences.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useWorkspace } from "@/components/providers/workspace-provider";
+
+export function WorkspacePreferences() {
+  const { organization, project, updateOrganization, updateProject } = useWorkspace();
+  const [organizationName, setOrganizationName] = useState(organization.name);
+  const [billingEmail, setBillingEmail] = useState(organization.billingEmail);
+  const [plan, setPlan] = useState(organization.plan);
+  const [projectName, setProjectName] = useState(project.name);
+  const [projectDescription, setProjectDescription] = useState(project.description ?? "");
+
+  useEffect(() => {
+    setOrganizationName(organization.name);
+    setBillingEmail(organization.billingEmail);
+    setPlan(organization.plan);
+  }, [organization]);
+
+  useEffect(() => {
+    setProjectName(project.name);
+    setProjectDescription(project.description ?? "");
+  }, [project]);
+
+  const handleOrganizationSave = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    updateOrganization(organization.id, {
+      name: organizationName.trim() || organization.name,
+      billingEmail: billingEmail.trim() || organization.billingEmail,
+      plan: plan as typeof organization.plan,
+    });
+  };
+
+  const handleProjectSave = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    updateProject(organization.id, project.id, {
+      name: projectName.trim() || project.name,
+      description: projectDescription.trim() || undefined,
+    });
+  };
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-2">
+      <Card className="border-border/70 bg-card/40">
+        <CardHeader>
+          <CardTitle>Organization</CardTitle>
+          <CardDescription>Update display information for invoices and shared workspaces.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleOrganizationSave} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="organization-name">Organization name</Label>
+              <Input
+                id="organization-name"
+                value={organizationName}
+                onChange={(event) => setOrganizationName(event.target.value)}
+                placeholder="Atlas Labs"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="organization-email">Billing email</Label>
+              <Input
+                id="organization-email"
+                type="email"
+                value={billingEmail}
+                onChange={(event) => setBillingEmail(event.target.value)}
+                placeholder="finance@atlas.ai"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="organization-plan">Plan</Label>
+              <select
+                id="organization-plan"
+                className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+                value={plan}
+                onChange={(event) => setPlan(event.target.value as typeof organization.plan)}
+              >
+                <option value="Starter">Starter</option>
+                <option value="Pro">Pro</option>
+                <option value="Enterprise">Enterprise</option>
+              </select>
+            </div>
+            <Button type="submit">Save organization</Button>
+          </form>
+        </CardContent>
+      </Card>
+      <Card className="border-border/70 bg-card/40">
+        <CardHeader>
+          <CardTitle>Active project</CardTitle>
+          <CardDescription>Adjust the details for the currently selected project.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleProjectSave} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="project-name">Project name</Label>
+              <Input
+                id="project-name"
+                value={projectName}
+                onChange={(event) => setProjectName(event.target.value)}
+                placeholder="Support assistant"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="project-description">Description</Label>
+              <Input
+                id="project-description"
+                value={projectDescription}
+                onChange={(event) => setProjectDescription(event.target.value)}
+                placeholder="Describe what this project powers"
+              />
+            </div>
+            <Button type="submit">Save project</Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+

--- a/components/settings/workspace-summary.tsx
+++ b/components/settings/workspace-summary.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useWorkspace } from "@/components/providers/workspace-provider";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+const planCopy: Record<string, { headline: string; description: string }> = {
+  Starter: {
+    headline: "Starter plan",
+    description: "Ideal for prototyping and small workloads with generous rate limits.",
+  },
+  Pro: {
+    headline: "Pro plan",
+    description: "Scaled concurrency with dedicated support for growing teams.",
+  },
+  Enterprise: {
+    headline: "Enterprise plan",
+    description: "Custom contracts, private networking, and 24/7 coverage.",
+  },
+};
+
+export function WorkspaceSummary() {
+  const { organization, project } = useWorkspace();
+  const plan = planCopy[organization.plan] ?? planCopy.Starter;
+
+  return (
+    <div className="grid gap-4 md:grid-cols-3">
+      <Card className="border-border/70 bg-card/40">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">Plan</CardTitle>
+          <CardDescription>{plan.headline}</CardDescription>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground">
+          <p>{plan.description}</p>
+        </CardContent>
+      </Card>
+      <Card className="border-border/70 bg-card/40">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">Billing contact</CardTitle>
+          <CardDescription>Where invoices and quota alerts are delivered.</CardDescription>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground">
+          <p className="font-medium text-foreground">{organization.billingEmail}</p>
+          <p className="mt-1">Update these details whenever your finance team changes.</p>
+        </CardContent>
+      </Card>
+      <Card className="border-border/70 bg-card/40">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">Active project</CardTitle>
+          <CardDescription>Currently routing console actions.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm text-muted-foreground">
+          <div>
+            <p className="font-medium text-foreground">{project.name}</p>
+            {project.description ? <p>{project.description}</p> : null}
+          </div>
+          <p>Switch projects from the header or promote new builds here.</p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/lib/auth-secret.ts
+++ b/lib/auth-secret.ts
@@ -1,0 +1,54 @@
+const SECRET_MIN_LENGTH = 32;
+const DEFAULT_SECRET_SEED = "atlas-local-development-secret";
+
+const directSecretEnvOrder = [
+  "NEXTAUTH_SECRET",
+  "AUTH_SECRET",
+  "AUTHJS_SECRET",
+  "NEXT_PUBLIC_NEXTAUTH_SECRET",
+] as const;
+
+const derivedSecretEnvOrder = [
+  "VERCEL_DEPLOYMENT_ID",
+  "VERCEL_URL",
+  "NEXTAUTH_URL",
+] as const;
+
+function coalesceEnvValue(keys: readonly string[]) {
+  for (const key of keys) {
+    const value = process.env[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function deriveDeterministicSecret(seed: string) {
+  if (!seed) {
+    seed = DEFAULT_SECRET_SEED;
+  }
+
+  const hex = Array.from(seed, (char) =>
+    char.charCodeAt(0).toString(16).padStart(2, "0"),
+  ).join("");
+
+  if (hex.length >= SECRET_MIN_LENGTH) {
+    return hex;
+  }
+
+  const repeatCount = Math.ceil(SECRET_MIN_LENGTH / hex.length);
+  return hex.repeat(repeatCount).slice(0, SECRET_MIN_LENGTH);
+}
+
+export function resolveNextAuthSecret() {
+  const directSecret = coalesceEnvValue(directSecretEnvOrder);
+  if (directSecret) {
+    return directSecret;
+  }
+
+  const derivedSeed =
+    coalesceEnvValue(derivedSecretEnvOrder) ?? DEFAULT_SECRET_SEED;
+
+  return deriveDeterministicSecret(derivedSeed);
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -5,15 +5,28 @@ import { getServerSession } from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
 import { z } from "zod";
 
-import { prisma } from "./prisma";
+import { prisma, prismaReady, isDatabaseConfigured } from "./prisma";
+import { resolveNextAuthSecret } from "./auth-secret";
+import { getDemoUserConfig } from "./demo-user";
 
 const credentialsSchema = z.object({
   email: z.string().email({ message: "Valid email is required" }),
   password: z.string().min(6, { message: "Password is required" }),
 });
 
+const demoUserConfig = getDemoUserConfig();
+
+const resolvedAuthSecret = resolveNextAuthSecret();
+
+if (!process.env.NEXTAUTH_SECRET) {
+  process.env.NEXTAUTH_SECRET = resolvedAuthSecret;
+}
+
+await prismaReady;
+
 export const authOptions: NextAuthOptions = {
-  adapter: PrismaAdapter(prisma),
+  secret: resolvedAuthSecret,
+  adapter: isDatabaseConfigured ? PrismaAdapter(prisma) : undefined,
   session: {
     strategy: "jwt",
   },
@@ -35,6 +48,31 @@ export const authOptions: NextAuthOptions = {
         }
 
         const { email, password } = parsed.data;
+
+        if (!isDatabaseConfigured) {
+          const normalizedEmail = email.trim().toLowerCase();
+          const normalizedDemoEmail = demoUserConfig.email.trim().toLowerCase();
+
+          if (normalizedEmail !== normalizedDemoEmail) {
+            throw new Error("No user found with that email");
+          }
+
+          const passwordMatches = demoUserConfig.passwordHash
+            ? await compare(password, demoUserConfig.passwordHash)
+            : demoUserConfig.password !== null && password === demoUserConfig.password;
+
+          if (!passwordMatches) {
+            throw new Error("Invalid email or password");
+          }
+
+          return {
+            id: demoUserConfig.id,
+            email: demoUserConfig.email,
+            name: demoUserConfig.name,
+          };
+        }
+
+        await prismaReady;
 
         const user = await prisma.user.findUnique({
           where: { email },
@@ -63,7 +101,8 @@ export const authOptions: NextAuthOptions = {
       if (user) {
         token.name = user.name;
         token.email = user.email;
-      } else if (token.sub && (!token.name || !token.email)) {
+      } else if (isDatabaseConfigured && token.sub && (!token.name || !token.email)) {
+        await prismaReady;
         const dbUser = await prisma.user.findUnique({
           where: { id: token.sub },
           select: { name: true, email: true },

--- a/lib/demo-user.ts
+++ b/lib/demo-user.ts
@@ -1,0 +1,41 @@
+const DEFAULT_EMAIL = "demo@atlas.ai";
+const DEFAULT_PASSWORD = "AtlasDemo!2025";
+const DEFAULT_NAME = "Atlas Demo";
+const DEFAULT_ID = "demo-user";
+
+export type DemoUserConfig = {
+  id: string;
+  email: string;
+  name: string;
+  password: string | null;
+  passwordHash: string | null;
+};
+
+let memoizedConfig: DemoUserConfig | null = null;
+
+export function getDemoUserConfig(): DemoUserConfig {
+  if (memoizedConfig) {
+    return memoizedConfig;
+  }
+
+  const passwordHash = process.env.DEMO_USER_PASSWORD_HASH?.trim() || null;
+  const passwordFromEnv = process.env.DEMO_USER_PASSWORD?.trim();
+
+  memoizedConfig = {
+    id: process.env.DEMO_USER_ID?.trim() || DEFAULT_ID,
+    email: process.env.DEMO_USER_EMAIL?.trim() || DEFAULT_EMAIL,
+    name: process.env.DEMO_USER_NAME?.trim() || DEFAULT_NAME,
+    password: passwordFromEnv ?? (passwordHash ? null : DEFAULT_PASSWORD),
+    passwordHash,
+  };
+
+  return memoizedConfig;
+}
+
+export function getPublicDemoCredentialSummary() {
+  const { email, password, passwordHash } = getDemoUserConfig();
+  return {
+    email,
+    password: passwordHash ? null : password,
+  };
+}

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -1,0 +1,543 @@
+export type Locale = "es" | "en";
+
+type Dictionary = Record<string, unknown>;
+
+export const dictionaries: Record<Locale, Dictionary> = {
+  es: {
+    common: {
+      appName: "Atlas Console",
+      organizationPlan: "Plan",
+      contactSales: "Contacta ventas",
+      billingContact: "Contacto de facturación",
+      loading: "Cargando…",
+      noData: "Sin datos disponibles",
+    },
+    auth: {
+      brand: "Proveedor de inferencia de confianza",
+      title: "Inicia sesión",
+      subtitle:
+        "Gestiona credenciales, espacios de trabajo y modelos de Hugging Face y Together AI desde un único panel.",
+      welcome: "Te damos la bienvenida",
+      description: "Introduce tus credenciales para acceder al panel.",
+      emailLabel: "Correo electrónico",
+      emailPlaceholder: "tú@empresa.com",
+      passwordLabel: "Contraseña",
+      submit: "Iniciar sesión",
+      submitting: "Iniciando…",
+      requestAccess: "Solicitar acceso",
+      createPrompt: "¿No tienes una cuenta?",
+      oauthDivider: "o continúa con",
+      google: "Google",
+      github: "GitHub",
+      errors: {
+        email: "Introduce un correo válido",
+        password: "La contraseña debe tener al menos 8 caracteres",
+        generic: "No se pudo iniciar sesión. Inténtalo nuevamente.",
+      },
+    },
+    header: {
+      console: "Consola Atlas",
+      searchPlaceholder: "Busca en documentación, guías o estado…",
+      status: "Estado",
+      docs: "Documentación",
+      support: "Soporte",
+      signOut: "Cerrar sesión",
+    },
+    navigation: {
+      sections: {
+        overview: "Resumen",
+        workspace: "Espacio de trabajo",
+        build: "Construir",
+        security: "Seguridad",
+      },
+      items: {
+        dashboard: "Panel",
+        workspace: "Espacio",
+        projects: "Proyectos",
+        playground: "Playground",
+        docs: "Docs",
+        keys: "Claves API",
+        account: "Cuenta",
+      },
+      accessibility: {
+        open: "Abrir navegación",
+        close: "Cerrar navegación",
+        dismiss: "Cerrar superposición",
+      },
+    },
+    sidebar: {
+      billingContact: "Contacto de facturación",
+      needAccess: "¿Necesitas acceso a producción?",
+      contactSales: "Contacta ventas",
+    },
+    pageHeader: {
+      viewDocs: "Ver documentación",
+    },
+    dashboard: {
+      title: "Panel",
+      description: "Supervisa salud, consumo y cumplimiento de tu plataforma Atlas.",
+      statusPill: "Sistemas nominales",
+      statusPeriod: "Últimas 24h · iad1",
+      compliance: "SOC2 Tipo II · HIPAA",
+      statusHistory: "Historial de estado",
+      filters: "Filtros",
+      metrics: {
+        requests: "Solicitudes (30d)",
+        tokens: "Consumo de tokens",
+        voice: "Minutos de voz",
+        images: "Imágenes generadas",
+      },
+      metricsDelta: {
+        requests: "+8.4%",
+        tokens: "Límite 20M",
+        voice: "+112 en vivo",
+        images: "Reinicio en 6d",
+      },
+      httpTitle: "Códigos HTTP",
+      httpDescription: "Volumen de las últimas 24 horas",
+      openMetrics: "Abrir métricas",
+      latencyTitle: "Latencia y disponibilidad",
+      latencyDescription: "Streaming y peticiones estándar",
+      p95: "Latencia P95",
+      availability: "Disponibilidad",
+      availabilityNote:
+        "Atlas sondea todas las regiones cada 60 segundos. Configura alertas en las políticas de proyecto.",
+      apiCredentialsTitle: "Credenciales API",
+      apiCredentialsDescription: "Claves recientes y ámbitos asignados.",
+      manageKeys: "Administrar claves",
+      activityTitle: "Actividad reciente",
+      activityDescription: "Eventos de auditoría.",
+      emptyActivity: "No hay eventos recientes.",
+      createKey: "Crear clave API",
+      availableModelsTitle: "Modelos disponibles",
+      availableModelsDescription:
+        "Provisiona modelos de lenguaje, voz e imagen de Hugging Face y Together AI para cada entorno del proyecto.",
+      integrationGuide: "Guía de integración",
+      modelTable: {
+        model: "Modelo",
+        modality: "Modalidad",
+        context: "Contexto",
+        release: "Versión",
+        tokensLabel: "tokens",
+        unknown: "—",
+      },
+      activity: {
+        entries: {
+          voice: {
+            title: "Prototipo de voz desplegado",
+            description: "Streaming TTS disponible en fra1",
+            time: "Hoy, 12:24",
+          },
+          key: {
+            title: "Clave rotada",
+            description: "Credencial de webhook de producción regenerada",
+            time: "Ayer, 18:07",
+          },
+          policy: {
+            title: "Política actualizada",
+            description: "Límites del playground incrementados a 120 RPM",
+            time: "16 Sep, 09:42",
+          },
+        },
+      },
+    },
+    apiKeys: {
+      heading: "Claves API",
+      description: "Genera y administra credenciales para tus integraciones.",
+      create: "Crear clave",
+      filters: {
+        all: "Todas",
+        language: "Lenguaje",
+        speech: "Voz",
+        vision: "Visión",
+      },
+      loading: "Cargando claves…",
+      activeWorkspace: "Espacio activo",
+      table: {
+        label: "Etiqueta",
+        models: "Modelos",
+        created: "Creada",
+        actions: "Acciones",
+        copy: "Copiar",
+        revoke: "Revocar",
+        empty: "Aún no hay claves",
+      },
+      errors: {
+        load: "No se pudieron cargar las claves API",
+        models: "No se pudieron cargar los modelos disponibles",
+        revoke: "No se pudo revocar la clave",
+        generate: "No se pudo generar la clave",
+      },
+      dialog: {
+        title: "Crear nueva clave",
+        description: "Restringe la clave a los modelos necesarios. Puedes rotarla en cualquier momento.",
+        label: "Etiqueta",
+        labelPlaceholder: "Webhook de producción",
+        labelHelp: "Opcional. Solo visible en el panel.",
+        modelAccess: "Acceso a modelos",
+        cancel: "Cancelar",
+        submit: "Crear clave",
+        generating: "Creando…",
+        error: "Selecciona al menos un modelo o deja la clave sin ámbito.",
+      },
+      generated: {
+        title: "Nueva clave generada",
+        description: "Guarda la clave ahora; no volverá a mostrarse completa.",
+        copy: "Copiar clave",
+        close: "Cerrar",
+        scopes: "Ámbitos",
+      },
+      list: {
+        unscoped: "Sin ámbito",
+        summaryUnscoped: "Sin ámbito",
+        summaryNone: "Sin claves",
+        rotateNotice:
+          "Rota con frecuencia las credenciales de producción. Revisa la lista de endurecimiento antes de desplegar.",
+        checklist: "Lista de verificación",
+      },
+      page: {
+        reminder:
+          "Atlas solo muestra los secretos recién generados una vez. Guárdalos en tu gestor seguro y usa claves distintas para pruebas y producción.",
+        automation:
+          "¿Necesitas automatizar la rotación? Llama a los endpoints /api/keys desde tus canalizaciones de CI o tu proveedor de infraestructura.",
+      },
+    },
+    theme: {
+      light: "Claro",
+      dark: "Oscuro",
+      toggleLabel: "Cambiar tema",
+    },
+    locale: {
+      toggleLabel: "Cambiar idioma",
+      es: "Español",
+      en: "Inglés",
+    },
+    projects: {
+      title: "Proyectos",
+      description: "Estructura tu uso de Atlas por proyecto para aislar credenciales, cuotas y auditorías.",
+      policiesTitle: "Políticas del espacio",
+      policiesDescription: "Controla cómo los nuevos proyectos heredan el acceso.",
+      defaultAccessTitle: "Acceso predeterminado",
+      defaultAccessBody: "Los proyectos nuevos comienzan con acceso de solo lectura al entorno de staging compartido.",
+      lifecycleTitle: "Ciclo de vida",
+      lifecycleBody:
+        "Después de la revisión de seguridad, promociona los proyectos a producción para habilitar cuotas en vivo y creación de claves API.",
+      table: {
+        intro: "Los proyectos agrupan credenciales, consumo y auditoría para cada superficie.",
+        name: "Nombre",
+        region: "Región",
+        status: "Estado",
+        created: "Creado",
+        actions: "Acciones",
+        placeholder: "Añade una descripción breve",
+        active: "Activo",
+        setActive: "Activar",
+      },
+      status: {
+        active: "Activo",
+        review: "En revisión",
+        paused: "Pausado",
+      },
+      dialog: {
+        title: "Crear nuevo proyecto",
+        body:
+          "Los proyectos aíslan credenciales, cuotas y métricas. Puedes cambiar entre ellos cuando quieras.",
+        name: "Nombre del proyecto",
+        namePlaceholder: "Aplicación de producción",
+        slug: "Slug",
+        slugPlaceholder: "mi-aplicacion-produccion",
+        region: "Región",
+        descriptionLabel: "Descripción",
+        descriptionPlaceholder: "¿Qué potencia este proyecto?",
+        cancel: "Cancelar",
+        submit: "Crear proyecto",
+      },
+      regions: {
+        iad1: "iad1 · EE. UU. Este",
+        sfo3: "sfo3 · EE. UU. Oeste",
+        fra1: "fra1 · UE Central",
+        sin1: "sin1 · AP Sudeste",
+      },
+    },
+  },
+  en: {
+    common: {
+      appName: "Atlas Console",
+      organizationPlan: "Plan",
+      contactSales: "Contact sales",
+      billingContact: "Billing contact",
+      loading: "Loading…",
+      noData: "No data available",
+    },
+    auth: {
+      brand: "Trusted inference provider",
+      title: "Sign in",
+      subtitle:
+        "Manage credentials, workspaces, and Hugging Face + Together AI models from a unified console.",
+      welcome: "Welcome back",
+      description: "Use your credentials to access the console.",
+      emailLabel: "Email",
+      emailPlaceholder: "you@company.com",
+      passwordLabel: "Password",
+      submit: "Sign in",
+      submitting: "Signing in…",
+      requestAccess: "Request access",
+      createPrompt: "Don’t have an account?",
+      oauthDivider: "or continue with",
+      google: "Google",
+      github: "GitHub",
+      errors: {
+        email: "Enter a valid email",
+        password: "Password must be at least 8 characters",
+        generic: "We couldn’t sign you in. Please try again.",
+      },
+    },
+    header: {
+      console: "Atlas Console",
+      searchPlaceholder: "Search docs, guides, or status…",
+      status: "Status",
+      docs: "Docs",
+      support: "Support",
+      signOut: "Sign out",
+    },
+    navigation: {
+      sections: {
+        overview: "Overview",
+        workspace: "Workspace",
+        build: "Build",
+        security: "Security",
+      },
+      items: {
+        dashboard: "Dashboard",
+        workspace: "Workspace",
+        projects: "Projects",
+        playground: "Playground",
+        docs: "Docs",
+        keys: "API keys",
+        account: "Account",
+      },
+      accessibility: {
+        open: "Open navigation",
+        close: "Close navigation",
+        dismiss: "Dismiss navigation overlay",
+      },
+    },
+    sidebar: {
+      billingContact: "Billing contact",
+      needAccess: "Need production access?",
+      contactSales: "Contact sales",
+    },
+    pageHeader: {
+      viewDocs: "View documentation",
+    },
+    dashboard: {
+      title: "Dashboard",
+      description: "Monitor platform health, usage, and compliance across Atlas.",
+      statusPill: "Systems nominal",
+      statusPeriod: "Last 24 hours · iad1",
+      compliance: "SOC2 Type II · HIPAA",
+      statusHistory: "View status history",
+      filters: "Filters",
+      metrics: {
+        requests: "Requests (30d)",
+        tokens: "Token consumption",
+        voice: "Voice minutes",
+        images: "Image renders",
+      },
+      metricsDelta: {
+        requests: "+8.4%",
+        tokens: "Cap 20M",
+        voice: "+112 live",
+        images: "Reset in 6d",
+      },
+      httpTitle: "HTTP status codes",
+      httpDescription: "Volume over the past 24 hours",
+      openMetrics: "Open metrics",
+      latencyTitle: "Latency & availability",
+      latencyDescription: "Streaming + standard requests",
+      p95: "P95 latency",
+      availability: "Availability",
+      availabilityNote:
+        "Atlas pings every deployed region every 60 seconds. Configure alerts in the project policies panel.",
+      apiCredentialsTitle: "API credentials",
+      apiCredentialsDescription: "Recent keys and scoped access.",
+      manageKeys: "Manage keys",
+      activityTitle: "Recent activity",
+      activityDescription: "Audit-grade events.",
+      emptyActivity: "No recent events.",
+      createKey: "Create API key",
+      availableModelsTitle: "Available models",
+      availableModelsDescription:
+        "Provision language, speech, and vision models from Hugging Face and Together AI for every project environment.",
+      integrationGuide: "Integration guide",
+      modelTable: {
+        model: "Model",
+        modality: "Modality",
+        context: "Context",
+        release: "Release",
+        tokensLabel: "tokens",
+        unknown: "—",
+      },
+      activity: {
+        entries: {
+          voice: {
+            title: "Voice prototype deployed",
+            description: "Streaming TTS live in fra1",
+            time: "Today, 12:24",
+          },
+          key: {
+            title: "Key rotated",
+            description: "Production webhook credential regenerated",
+            time: "Yesterday, 18:07",
+          },
+          policy: {
+            title: "Policy updated",
+            description: "Playground rate limits increased to 120 RPM",
+            time: "Sep 16, 09:42",
+          },
+        },
+      },
+    },
+    apiKeys: {
+      heading: "API keys",
+      description: "Generate and manage credentials for your integrations.",
+      create: "Create key",
+      filters: {
+        all: "All",
+        language: "Language",
+        speech: "Speech",
+        vision: "Vision",
+      },
+      loading: "Loading keys…",
+      activeWorkspace: "Active workspace",
+      table: {
+        label: "Label",
+        models: "Models",
+        created: "Created",
+        actions: "Actions",
+        copy: "Copy",
+        revoke: "Revoke",
+        empty: "No keys yet",
+      },
+      errors: {
+        load: "Unable to load API keys",
+        models: "Unable to load models",
+        revoke: "Unable to revoke key",
+        generate: "Unable to generate key",
+      },
+      dialog: {
+        title: "Create a new API key",
+        description: "Scope the key to the models you need. Rotate or revoke at any time.",
+        label: "Label",
+        labelPlaceholder: "Production webhook",
+        labelHelp: "Optional. Only visible in this dashboard.",
+        modelAccess: "Model access",
+        cancel: "Cancel",
+        submit: "Create key",
+        generating: "Creating…",
+        error: "Select at least one model or leave the key unscoped.",
+      },
+      generated: {
+        title: "New API key generated",
+        description: "This is the only time the full key is shown. Store it securely.",
+        copy: "Copy key",
+        close: "Close",
+        scopes: "Scopes",
+      },
+      list: {
+        unscoped: "Unscoped",
+        summaryUnscoped: "Unscoped",
+        summaryNone: "No keys yet",
+        rotateNotice:
+          "Rotate production credentials regularly. Review the hardening checklist before shipping.",
+        checklist: "Hardening checklist",
+      },
+      page: {
+        reminder:
+          "Atlas only surfaces new secrets once. Store them in your vault and keep separate keys for staging and production.",
+        automation:
+          "Need automated rotation? Call the /api/keys endpoints from your CI pipelines or infrastructure tooling.",
+      },
+    },
+    theme: {
+      light: "Light",
+      dark: "Dark",
+      toggleLabel: "Toggle theme",
+    },
+    locale: {
+      toggleLabel: "Toggle language",
+      es: "Spanish",
+      en: "English",
+    },
+    projects: {
+      title: "Projects",
+      description: "Structure your Atlas usage by project to isolate credentials, quotas, and audit logs.",
+      policiesTitle: "Workspace policies",
+      policiesDescription: "Control how new projects inherit access.",
+      defaultAccessTitle: "Default access",
+      defaultAccessBody: "New projects start with read-only access to the shared staging environment.",
+      lifecycleTitle: "Lifecycle",
+      lifecycleBody:
+        "After security review, promote projects to production to unlock live quotas and API key creation.",
+      table: {
+        intro: "Projects group credentials, usage, and auditing for a specific surface area.",
+        name: "Name",
+        region: "Region",
+        status: "Status",
+        created: "Created",
+        actions: "Actions",
+        placeholder: "Add a short description",
+        active: "Active",
+        setActive: "Set active",
+      },
+      status: {
+        active: "Active",
+        review: "In review",
+        paused: "Paused",
+      },
+      dialog: {
+        title: "Create a new project",
+        body: "Projects isolate API credentials, quotas, and metrics. You can switch between them at any time.",
+        name: "Project name",
+        namePlaceholder: "My production app",
+        slug: "Slug",
+        slugPlaceholder: "my-production-app",
+        region: "Region",
+        descriptionLabel: "Description",
+        descriptionPlaceholder: "What does this project power?",
+        cancel: "Cancel",
+        submit: "Create project",
+      },
+      regions: {
+        iad1: "iad1 · US East",
+        sfo3: "sfo3 · US West",
+        fra1: "fra1 · EU Central",
+        sin1: "sin1 · AP Southeast",
+      },
+    },
+  },
+};
+
+export function translate(dictionary: Dictionary, key: string): string {
+  if (!key) return key;
+  const path = key.split(".");
+  let value: unknown = dictionary;
+  for (const segment of path) {
+    if (value && typeof value === "object" && segment in (value as Record<string, unknown>)) {
+      value = (value as Record<string, unknown>)[segment];
+    } else {
+      return key;
+    }
+  }
+
+  return typeof value === "string" ? value : key;
+}
+
+export function getDictionary(locale: Locale): Dictionary {
+  return dictionaries[locale];
+}
+
+export function isLocale(value: string | undefined | null): value is Locale {
+  return value === "es" || value === "en";
+}
+

--- a/lib/i18n/server.ts
+++ b/lib/i18n/server.ts
@@ -1,0 +1,22 @@
+import "server-only";
+
+import { cookies } from "next/headers";
+
+import { getDictionary, isLocale, type Locale } from "../i18n";
+
+const LOCALE_COOKIE = "ui-locale";
+
+export async function getServerLocale(): Promise<Locale> {
+  const cookieStore = await cookies();
+  const stored = cookieStore.get(LOCALE_COOKIE)?.value;
+  if (isLocale(stored)) {
+    return stored;
+  }
+  return "es";
+}
+
+export async function getServerDictionary(locale?: Locale) {
+  const resolvedLocale = locale ?? (await getServerLocale());
+  return getDictionary(resolvedLocale);
+}
+

--- a/lib/key-store.ts
+++ b/lib/key-store.ts
@@ -1,0 +1,79 @@
+import { randomBytes } from "crypto";
+import { promises as fs } from "fs";
+import path from "path";
+
+interface PersistedKeyRecord {
+  id: string;
+  key: string;
+  userId: string;
+  createdAt: string;
+  label?: string;
+  modelIds: string[];
+}
+
+const dataDirectory = path.join(process.cwd(), ".data");
+const storeFile = path.join(dataDirectory, "demo-api-keys.json");
+
+async function ensureStore() {
+  try {
+    await fs.mkdir(dataDirectory, { recursive: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+      throw error;
+    }
+  }
+
+  try {
+    await fs.access(storeFile);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      await fs.writeFile(storeFile, JSON.stringify({ keys: [] }, null, 2), "utf8");
+    } else {
+      throw error;
+    }
+  }
+}
+
+async function readStore(): Promise<PersistedKeyRecord[]> {
+  await ensureStore();
+  const raw = await fs.readFile(storeFile, "utf8");
+  const parsed = JSON.parse(raw) as { keys?: PersistedKeyRecord[] };
+  return Array.isArray(parsed.keys) ? parsed.keys : [];
+}
+
+async function writeStore(keys: PersistedKeyRecord[]) {
+  await ensureStore();
+  const payload = { keys };
+  await fs.writeFile(storeFile, JSON.stringify(payload, null, 2), "utf8");
+}
+
+export async function listKeysForUser(userId: string) {
+  const keys = await readStore();
+  return keys.filter((key) => key.userId === userId);
+}
+
+export async function createKeyForUser(userId: string, modelIds: string[], label?: string) {
+  const id = randomBytes(12).toString("hex");
+  const key = `sk-${randomBytes(24).toString("base64url")}`;
+  const createdAt = new Date().toISOString();
+  const record: PersistedKeyRecord = {
+    id,
+    key,
+    userId,
+    createdAt,
+    label: label?.trim() || undefined,
+    modelIds: Array.from(new Set(modelIds)),
+  };
+
+  const keys = await readStore();
+  keys.push(record);
+  await writeStore(keys);
+
+  return record;
+}
+
+export async function deleteKeyForUser(userId: string, keyId: string) {
+  const keys = await readStore();
+  const nextKeys = keys.filter((key) => !(key.userId === userId && key.id === keyId));
+  await writeStore(nextKeys);
+}

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -1,0 +1,87 @@
+export type ModelCategory = "llm" | "tts" | "image";
+
+export interface ModelDefinition {
+  id: string;
+  name: string;
+  category: ModelCategory;
+  shortDescription: string;
+  contextWindow?: number;
+  defaultUseCase: string;
+  release: string;
+  latency?: string;
+}
+
+export const modelCatalog: ModelDefinition[] = [
+  {
+    id: "atlas-llm-pro",
+    name: "Atlas LLM Pro",
+    category: "llm",
+    shortDescription: "Flagship reasoning model with 200K token context window.",
+    contextWindow: 200_000,
+    defaultUseCase: "Enterprise knowledge copilots and complex orchestration pipelines.",
+    release: "2025.03",
+    latency: "~1.8s first token",
+  },
+  {
+    id: "atlas-llm-lite",
+    name: "Atlas LLM Lite",
+    category: "llm",
+    shortDescription: "Cost optimised chat model tuned for fast support flows.",
+    contextWindow: 64_000,
+    defaultUseCase: "Customer support assistants, lightweight automations, summarisation.",
+    release: "2025.01",
+    latency: "~900ms first token",
+  },
+  {
+    id: "atlas-llm-code",
+    name: "Atlas LLM Code",
+    category: "llm",
+    shortDescription: "Code generation specialist with repository level context ingest.",
+    contextWindow: 128_000,
+    defaultUseCase: "Pair programming, migration assistance, static analysis with natural language outputs.",
+    release: "2024.12",
+    latency: "~2.2s first token",
+  },
+  {
+    id: "atlas-voice-studio",
+    name: "Atlas Voice Studio",
+    category: "tts",
+    shortDescription: "Neural TTS with expressive prosody controls and 20+ voices.",
+    defaultUseCase: "Interactive voice assistants, localisation pipelines, marketing content.",
+    release: "2025.02",
+    latency: "Streaming <250ms",
+  },
+  {
+    id: "atlas-voice-lite",
+    name: "Atlas Voice Lite",
+    category: "tts",
+    shortDescription: "Lightweight speech synthesis ideal for IVR and IoT devices.",
+    defaultUseCase: "Transaction notifications, embedded devices, accessibility cues.",
+    release: "2024.11",
+    latency: "Streaming <180ms",
+  },
+  {
+    id: "atlas-vision-diffuse",
+    name: "Atlas Vision Diffuse",
+    category: "image",
+    shortDescription: "Text-to-image diffusion tuned for photorealistic renders.",
+    defaultUseCase: "Product marketing visuals, concept art, virtual staging.",
+    release: "2025.04",
+    latency: "1.4s per frame",
+  },
+  {
+    id: "atlas-vision-illustrate",
+    name: "Atlas Vision Illustrate",
+    category: "image",
+    shortDescription: "Illustration focused diffusion with stylised control presets.",
+    defaultUseCase: "Storyboarding, editorial artwork, motion graphic frames.",
+    release: "2024.10",
+    latency: "1.1s per frame",
+  },
+];
+
+const modelMap = new Map(modelCatalog.map((model) => [model.id, model]));
+
+export function getModelById(modelId: string): ModelDefinition | undefined {
+  return modelMap.get(modelId);
+}

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,10 +1,54 @@
 import { PrismaClient } from "@prisma/client";
 
+const DATABASE_ENV_KEYS = [
+  "DATABASE_URL",
+  "POSTGRES_PRISMA_URL",
+  "POSTGRES_URL_NON_POOLING",
+  "POSTGRES_URL",
+  "SUPABASE_DB_URL",
+] as const;
+
+const PLACEHOLDER_DATABASE_URL = "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+
+type ResolvedDatabaseUrl = {
+  url: string;
+  fromEnvironment: boolean;
+};
+
+function resolveDatabaseUrl(): ResolvedDatabaseUrl {
+  for (const key of DATABASE_ENV_KEYS) {
+    const value = process.env[key]?.trim();
+    if (value) {
+      if (key !== "DATABASE_URL") {
+        process.env.DATABASE_URL = value;
+      }
+      return { url: value, fromEnvironment: true };
+    }
+  }
+
+  if (!process.env.DATABASE_URL) {
+    process.env.DATABASE_URL = PLACEHOLDER_DATABASE_URL;
+  }
+
+  return { url: process.env.DATABASE_URL, fromEnvironment: process.env.DATABASE_URL !== PLACEHOLDER_DATABASE_URL };
+}
+
+const { url: databaseUrl, fromEnvironment } = resolveDatabaseUrl();
+
 const globalForPrisma = globalThis as unknown as {
   prisma?: PrismaClient;
 };
 
-export const prisma = globalForPrisma.prisma ?? new PrismaClient();
+export const prisma = globalForPrisma.prisma ?? new PrismaClient({
+  datasources: {
+    db: {
+      url: databaseUrl,
+    },
+  },
+});
+
+export const prismaReady = Promise.resolve();
+export const isDatabaseConfigured = fromEnvironment;
 
 if (process.env.NODE_ENV !== "production") {
   globalForPrisma.prisma = prisma;

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,18 @@
-export { default } from "next-auth/middleware";
+import { withAuth } from "next-auth/middleware";
+
+import { resolveNextAuthSecret } from "./lib/auth-secret";
+
+export default withAuth({
+  secret: resolveNextAuthSecret(),
+});
 
 export const config = {
-  matcher: ["/dashboard/:path*", "/playground/:path*", "/settings/:path*", "/api/keys/:path*", "/api/playground/:path*", "/api/settings/:path*"],
+  matcher: [
+    "/dashboard/:path*",
+    "/playground/:path*",
+    "/settings/:path*",
+    "/api/keys/:path*",
+    "/api/playground/:path*",
+    "/api/settings/:path*",
+  ],
 };

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build --turbopack",
+    "build": "prisma generate && next build --turbopack",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "db:seed": "prisma db seed"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -41,5 +42,8 @@
     "prisma": "^5.22.0",
     "tailwindcss": "^3.4.14",
     "typescript": "^5"
+  },
+  "prisma": {
+    "seed": "node prisma/seed.js"
   }
 }

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -1,0 +1,38 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const { PrismaClient } = require("@prisma/client");
+const { hash } = require("bcryptjs");
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const email = process.env.DEMO_USER_EMAIL?.trim() || "demo@atlas.ai";
+  const password = process.env.DEMO_USER_PASSWORD || "AtlasDemo!2025";
+  const name = process.env.DEMO_USER_NAME?.trim() || "Atlas Demo";
+
+  const hashedPassword = await hash(password, 12);
+
+  const user = await prisma.user.upsert({
+    where: { email },
+    create: {
+      email,
+      name,
+      password: hashedPassword,
+    },
+    update: {
+      name,
+      password: hashedPassword,
+    },
+  });
+
+  console.log(`Seeded demo user ${user.email} with password "${password}".`);
+  console.log("You can update or disable the demo credentials by setting DEMO_USER_* env vars before running the seed.");
+}
+
+main()
+  .catch((error) => {
+    console.error("Failed to seed demo user", error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
- add theme and locale providers with quick settings controls so users can toggle light/dark mode and switch between Spanish and English across the console
- restyle the landing sign-in screen with bilingual messaging, OAuth options, and Hugging Face/Together AI positioning while wiring server dictionaries for localized layouts
- translate dashboard, API key, and project views and improve the mobile API key creation dialog with a scrollable model selector

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce20bb4ad8832ba7f90d62e011656a